### PR TITLE
Additional prologues for PPC64 from clang output.

### DIFF
--- a/archinfo/arch_ppc64.py
+++ b/archinfo/arch_ppc64.py
@@ -20,6 +20,8 @@ class ArchPPC64(Arch):
         if endness == 'Iend_BE':
             self.function_prologs = {
                 r"\x94\x21[\x00-\xff]{2}\x7c\x08\x02\xa6",                        # stwu r1, -off(r1); mflr r0
+                r"(?!\x94\x21[\x00-\xff]{2})\x7c\x08\x02\xa6",                    # mflr r0
+                r"\xf8\x61[\x00-\xff]{2}",                                        # std r3, -off(r1)
             }
             self.function_epilogs = {
                 r"[\x00-\xff]{2}\x03\xa6([\x00-\xff]{4}){0,6}\x4e\x80\x00\x20"    # mtlr reg; ... ; blr


### PR DESCRIPTION
Added additional cases from clang output. In one case, `mflr r0` is the start of the prologue. In another, arguments from registers (`r3` being the first arg) are immediately stored on the stack.