### PR TITLE
Updates for PPC

### DIFF
--- a/archinfo/arch_ppc32.py
+++ b/archinfo/arch_ppc32.py
@@ -374,8 +374,6 @@ class ArchPPC32(Arch):
     }
 
     argument_registers = {
-        registers['r0'],
-        registers['r2'],
         registers['r3'],
         registers['r4'],
         registers['r5'],
@@ -384,27 +382,6 @@ class ArchPPC32(Arch):
         registers['r8'],
         registers['r9'],
         registers['r10'],
-        registers['r11'],
-        registers['r12'],
-        registers['r13'],
-        registers['r14'],
-        registers['r15'],
-        registers['r16'],
-        registers['r17'],
-        registers['r18'],
-        registers['r19'],
-        registers['r20'],
-        registers['r21'],
-        registers['r22'],
-        registers['r23'],
-        registers['r24'],
-        registers['r25'],
-        registers['r26'],
-        registers['r27'],
-        registers['r28'],
-        registers['r29'],
-        registers['r30'],
-        registers['r31'],
     }
 
     got_section_name = '.plt'

--- a/archinfo/arch_ppc32.py
+++ b/archinfo/arch_ppc32.py
@@ -384,6 +384,44 @@ class ArchPPC32(Arch):
         registers['r10'],
     }
 
+    argument_register_positions = {
+        registers['r3']: 0,
+        registers['r4']: 1,
+        registers['r5']: 2,
+        registers['r6']: 3,
+        registers['r7']: 4,
+        registers['r8']: 5,
+        registers['r9']: 6,
+        registers['r10']: 7,
+        # fp registers
+        registers['vsr1']: 0,
+        registers['vsr2']: 1,
+        registers['vsr3']: 2,
+        registers['vsr4']: 3,
+        registers['vsr5']: 4,
+        registers['vsr6']: 5,
+        registers['vsr7']: 6,
+        registers['vsr8']: 7,
+        registers['vsr9']: 8,
+        registers['vsr10']: 9,
+        registers['vsr11']: 10,
+        registers['vsr12']: 11,
+        registers['vsr13']: 12,
+        # vector registers
+        registers['vsr2']: 0,
+        registers['vsr3']: 1,
+        registers['vsr4']: 2,
+        registers['vsr5']: 3,
+        registers['vsr6']: 4,
+        registers['vsr7']: 5,
+        registers['vsr8']: 6,
+        registers['vsr9']: 7,
+        registers['vsr10']: 8,
+        registers['vsr11']: 9,
+        registers['vsr12']: 10,
+        registers['vsr13']: 11,
+    }
+
     got_section_name = '.plt'
     ld_linux_name = 'ld.so.1'
     elf_tls = TLSArchInfo(1, 52, [], [48], [], 0x7000, 0x8000)

--- a/archinfo/arch_ppc64.py
+++ b/archinfo/arch_ppc64.py
@@ -377,8 +377,6 @@ class ArchPPC64(Arch):
     }
 
     argument_registers = {
-        registers['r0'],
-        registers['r2'],
         registers['r3'],
         registers['r4'],
         registers['r5'],
@@ -386,28 +384,7 @@ class ArchPPC64(Arch):
         registers['r7'],
         registers['r8'],
         registers['r9'],
-        registers['r10'],
-        registers['r11'],
-        registers['r12'],
-        registers['r13'],
-        registers['r14'],
-        registers['r15'],
-        registers['r16'],
-        registers['r17'],
-        registers['r18'],
-        registers['r19'],
-        registers['r20'],
-        registers['r21'],
-        registers['r22'],
-        registers['r23'],
-        registers['r24'],
-        registers['r25'],
-        registers['r26'],
-        registers['r27'],
-        registers['r28'],
-        registers['r29'],
-        registers['r30'],
-        registers['r31'],
+        registers['r10']
     }
 
     got_section_name = '.plt'

--- a/archinfo/arch_ppc64.py
+++ b/archinfo/arch_ppc64.py
@@ -387,6 +387,44 @@ class ArchPPC64(Arch):
         registers['r10']
     }
 
+    argument_register_positions = {
+        registers['r3']: 0,
+        registers['r4']: 1,
+        registers['r5']: 2,
+        registers['r6']: 3,
+        registers['r7']: 4,
+        registers['r8']: 5,
+        registers['r9']: 6,
+        registers['r10']: 7,
+        # fp registers
+        registers['vsr1']: 0,
+        registers['vsr2']: 1,
+        registers['vsr3']: 2,
+        registers['vsr4']: 3,
+        registers['vsr5']: 4,
+        registers['vsr6']: 5,
+        registers['vsr7']: 6,
+        registers['vsr8']: 7,
+        registers['vsr9']: 8,
+        registers['vsr10']: 9,
+        registers['vsr11']: 10,
+        registers['vsr12']: 11,
+        registers['vsr13']: 12,
+        # vector registers
+        registers['vsr2']: 0,
+        registers['vsr3']: 1,
+        registers['vsr4']: 2,
+        registers['vsr5']: 3,
+        registers['vsr6']: 4,
+        registers['vsr7']: 5,
+        registers['vsr8']: 6,
+        registers['vsr9']: 7,
+        registers['vsr10']: 8,
+        registers['vsr11']: 9,
+        registers['vsr12']: 10,
+        registers['vsr13']: 11,
+    }
+    
     got_section_name = '.plt'
     ld_linux_name = 'ld64.so.1'
     elf_tls = TLSArchInfo(1, 92, [], [84], [], 0x7000, 0x8000)


### PR DESCRIPTION
Removed registers not used for parameter passing from the `argument_registers` set for PPC32 and PPC64. 

Added a new `argument_register_positions` dict that maps parameter registers to the position of the function parameter they hold. This is taken from the [Power ISA 2.06](http://citeseerx.ist.psu.edu/viewdoc/download;jsessionid=995FB78240B0A62F1629AB3454C3DFB7?doi=10.1.1.175.7365&rep=rep1&type=pdf).

The idea is to add an `argument_register_positions` for all other supported architectures. A `argument_stack_positions` would also be useful. Some calling conventions (e.g., cdecl) only use the stack to pass parameters. Another concern is that some calling conventions (e.g., standard PPC) use registers for the first _k_th parameters and all parameters may be stored on the stack at known offsets from the sp.