### PR TITLE
Add more flexibility to ARM/Thumb assembler

### DIFF
--- a/archinfo/arch.py
+++ b/archinfo/arch.py
@@ -289,7 +289,7 @@ class Arch(object):
             raise ArchError("Arch %s does not support assembly with Keystone" % self.name)
         if self._ks is None:
             self._ks = _keystone.Ks(self.ks_arch, self.ks_mode)
-        encoding, count = self._ks.asm(string, addr, as_bytes)
+        encoding, _ = self._ks.asm(string, addr, as_bytes)
         return encoding
 
     def translate_dynamic_tag(self, tag):

--- a/archinfo/arch_amd64.py
+++ b/archinfo/arch_amd64.py
@@ -112,7 +112,7 @@ class ArchAMD64(Arch):
                 self._ks.syntax = _keystone.KS_OPT_SYNTAX_GAS
             elif self.keystone_x86_syntax == 'radix16':
                 self._ks.syntax = _keystone.KS_OPT_SYNTAX_RADIX16
-        encoding, count = self._ks.asm(string, addr, as_bytes)
+        encoding, _ = self._ks.asm(string, addr, as_bytes)
         return encoding
 
     bits = 64

--- a/archinfo/arch_arm.py
+++ b/archinfo/arch_arm.py
@@ -54,6 +54,7 @@ class ArchARM(Arch):
         self._cs = None
         self._cs_thumb = None
         self._ks = None
+        self._ks_thumb = None
         return self.__dict__
 
     def __setstate__(self, data):
@@ -86,13 +87,11 @@ class ArchARM(Arch):
             return None
         if self.ks_arch is None:
             raise ArchError("Arch %s does not support assembly with Keystone" % self.name)
-        if self._ks is None:
-            if thumb:
-                self.ks_mode += _keystone.KS_MODE_THUMB
-            else:
-                self.ks_mode += _keystone.KS_MODE_ARM
-            self._ks = _keystone.Ks(self.ks_arch, self.ks_mode)
-        encoding, count = self._ks.asm(string, addr, as_bytes)
+        if self._ks is None or self._ks_thumb != thumb:
+            self._ks_thumb = thumb
+            mode = _keystone.KS_MODE_THUMB if thumb else _keystone.KS_MODE_ARM
+            self._ks = _keystone.Ks(self.ks_arch, self.ks_mode + mode)
+        encoding, _ = self._ks.asm(string, addr, as_bytes)
         return encoding
 
     @property
@@ -130,6 +129,7 @@ class ArchARM(Arch):
     if _keystone:
         ks_arch = _keystone.KS_ARCH_ARM
         ks_mode = _keystone.KS_MODE_LITTLE_ENDIAN
+    _ks_thumb = None
     uc_arch = _unicorn.UC_ARCH_ARM if _unicorn else None
     uc_mode = _unicorn.UC_MODE_LITTLE_ENDIAN if _unicorn else None
     uc_const = _unicorn.arm_const if _unicorn else None

--- a/archinfo/arch_x86.py
+++ b/archinfo/arch_x86.py
@@ -114,7 +114,7 @@ class ArchX86(Arch):
                 self._ks.syntax = _keystone.KS_OPT_SYNTAX_GAS
             elif self.keystone_x86_syntax == 'radix16':
                 self._ks.syntax = _keystone.KS_OPT_SYNTAX_RADIX16
-        encoding, count = self._ks.asm(string, addr, as_bytes)
+        encoding, _ = self._ks.asm(string, addr, as_bytes)
         return encoding
 
     bits = 32


### PR DESCRIPTION
This fixes #28 while keeping the Keystone "cache": we only call into Keystone when `thumb` changes.
@rhelmot @ltfish please review this