### PR TITLE
archinfo: python3 compatibility

### DIFF
--- a/archinfo/arch.py
+++ b/archinfo/arch.py
@@ -2,6 +2,7 @@ import logging
 import struct as _struct
 import platform as _platform
 import re
+import sys
 from archinfo.archerror import ArchError
 
 l = logging.getLogger("archinfo.arch")
@@ -26,6 +27,11 @@ try:
     import keystone as _keystone
 except ImportError:
     _keystone = None
+
+if sys.version_info[0] >= 3:
+    integer_types = int,
+else:
+    integer_types = (int, long)
 
 
 class Endness: # pylint: disable=no-init
@@ -315,7 +321,7 @@ class Arch(object):
         try:
             return self.dynamic_tag_translation[tag]
         except KeyError:
-            if isinstance(tag, (int, long)):
+            if isinstance(tag, integer_types):
                 l.error("Please look up and add dynamic tag type %#x for %s", tag, self.name)
             return tag
 
@@ -323,7 +329,7 @@ class Arch(object):
         try:
             return self.symbol_type_translation[tag]
         except KeyError:
-            if isinstance(tag, (int, long)):
+            if isinstance(tag, integer_types):
                 l.error("Please look up and add symbol type %#x for %s", tag, self.name)
             return tag
 
@@ -408,8 +414,8 @@ class Arch(object):
 
         return self.ks_arch is not None
 
-    address_types = (int, long)
-    function_address_types = (int, long)
+    address_types = integer_types
+    function_address_types = integer_types
 
     # various names
     name = None
@@ -532,7 +538,7 @@ def register_arch(regexes, bits, endness, my_arch):
             raise ValueError('Invalid Regular Expression %s' % rx)
     #if not isinstance(my_arch,Arch):
     #    raise TypeError("Arch must be a subclass of archinfo.Arch")
-    if not isinstance(bits, int):
+    if not isinstance(bits, integer_types):
         raise TypeError("Bits must be an int")
     if endness is not None:
         if endness != Endness.BE and endness != Endness.LE and endness != Endness.ME and endness != "any":


### PR DESCRIPTION
There could be more, but then something like the `future` package is needed to keep it maintainable.