### PR TITLE
Add support for R_ARM_THM_CALL relocation

### DIFF
--- a/archinfo/defines.py
+++ b/archinfo/defines.py
@@ -589,6 +589,7 @@ defines = {
     "R_ARM_THM_ABS5":                             0x7,
     "R_ARM_ABS8":                                 0x8,
     "R_ARM_SBREL32":                              0x9,
+    "R_ARM_THM_PC22":                             0xa,
     "R_ARM_THM_CALL":                             0xa,
     "R_ARM_THM_PC8":                              0xb,
     "R_ARM_AMP_VCALL9":                           0xc,

--- a/archinfo/defines.py
+++ b/archinfo/defines.py
@@ -589,7 +589,7 @@ defines = {
     "R_ARM_THM_ABS5":                             0x7,
     "R_ARM_ABS8":                                 0x8,
     "R_ARM_SBREL32":                              0x9,
-    "R_ARM_THM_PC22":                             0xa,
+    "R_ARM_THM_CALL":                             0xa,
     "R_ARM_THM_PC8":                              0xb,
     "R_ARM_AMP_VCALL9":                           0xc,
     "R_ARM_TLS_DESC":                             0xd,


### PR DESCRIPTION
This request adds archinfo support for R_ARM_THM_CALL via a new entry in `defines.py`. 

This request has a companion branch in cle also named fix/r_arm_thm_call. The cle branch implements `R_ARM_THM_CALL` at load time.