### PR TITLE
s390x: mark %r14 as a link register

### DIFF
--- a/archinfo/arch_s390x.py
+++ b/archinfo/arch_s390x.py
@@ -91,8 +91,12 @@ class ArchS390X(Arch):
                  general_purpose=True, persistent=True),
         Register(name='r13', size=8,
                  general_purpose=True, persistent=True),
+        # Strictly speaking, there is no fixed link register on s390x.
+        # However, %r14 is almost always used for that, so mark it as such.
+        # Situations when that's not the case (e.g. brasl %r0,X)
+        # can still be handled explicitly.
         Register(name='r14', size=8,
-                 general_purpose=True),
+                 general_purpose=True, alias_names=('lr',)),
         Register(name='r15', size=8, alias_names=('sp',),
                  general_purpose=True, persistent=True,
                  default_value=(initial_sp, True, 'global')),


### PR DESCRIPTION
Even though there is no fixed link register, %r14 is always used as
such.  With this change, I can finally build the s390x glibc CFG.

The long-term solution to handle unusual code is to introduce
SimStateHistory.jump_lr field, whose value can be computed by
SimEngineVEX._handle_irsb based on the last machine instruction
in the IRSB, then set by SimSuccessors._add_successor, and, when
non-None, used by SimSuccessorts._manage_callstack instead of
state.regs._lr.