### PR TITLE
Make arch objects hashable

### DIFF
--- a/archinfo/arch.py
+++ b/archinfo/arch.py
@@ -267,6 +267,9 @@ class Arch:
     def __repr__(self):
         return '<Arch %s (%s)>' % (self.name, self.memory_endness[-2:])
 
+    def __hash__(self):
+        return hash((self.name, self.bits, self.memory_endness))
+
     def __eq__(self, other):
         if not isinstance(other, Arch):
             return False


### PR DESCRIPTION
This commit adds the special [`__hash__`](https://docs.python.org/3/reference/datamodel.html#object.__hash__) method to the main `archinfo.Arch` class. This allows subclasses to then be hashable and used as keys in dictionaries, members in sets as well as included in other class's `__hash__` methods.

The members used for the hash operation were taken from the `__eq__` method such that two arch instances that are equivalent have the same hash.

```
In [1]: import archinfo

In [2]: x86 = archinfo.ArchX86()

In [3]: test = {}

In [4]: test[x86] = 'Hello World!'

In [5]: test[archinfo.ArchX86()]
Out[5]: 'Hello World!'

In [6]: test[archinfo.ArchAMD64()]
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-6-e021e192f830> in <module>()
----> 1 test[archinfo.ArchAMD64()]

KeyError: <Arch AMD64 (LE)>

In [7]: hash(x86)
Out[7]: 8400141866902529874

In [8]: hash(x86) == hash(archinfo.ArchX86())
Out[8]: True
```