### PR TITLE
Import without pyvex

### DIFF
--- a/archinfo/arch.py
+++ b/archinfo/arch.py
@@ -184,11 +184,11 @@ class Arch:
             self.ret_instruction = reverse_ends(self.ret_instruction)
             self.nop_instruction = reverse_ends(self.nop_instruction)
 
-        if self.register_list:
+        if self.register_list and _pyvex is not None:
             (_, _), max_offset = max(_pyvex.vex_ffi.guest_offsets.items(), key=lambda x: x[1])
             max_offset += self.bits
             # Register collections
-            if type(self.vex_arch) is str and _pyvex is not None:
+            if type(self.vex_arch) is str:
                 va = self.vex_arch[7:].lower() # pylint: disable=unsubscriptable-object
                 for r in self.register_list:
                     if r.vex_offset is None:

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,1 @@
+import archinfo

--- a/tests/test_import_no_capstone.py
+++ b/tests/test_import_no_capstone.py
@@ -1,0 +1,3 @@
+import sys
+sys.modules['capstone'] = None
+import archinfo

--- a/tests/test_import_no_keystone.py
+++ b/tests/test_import_no_keystone.py
@@ -1,0 +1,3 @@
+import sys
+sys.modules['keystone'] = None
+import archinfo

--- a/tests/test_import_no_pyvex.py
+++ b/tests/test_import_no_pyvex.py
@@ -1,0 +1,3 @@
+import sys
+sys.modules['pyvex'] = None
+import archinfo

--- a/tests/test_import_no_unicorn.py
+++ b/tests/test_import_no_unicorn.py
@@ -1,0 +1,3 @@
+import sys
+sys.modules['unicorn'] = None
+import archinfo


### PR DESCRIPTION
Fixes #62.  Includes testcases for importing archinfo in various conditions.