### PR TITLE
Define how to run tests in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,4 +15,6 @@ setup(
     version='8.19.10.30',
     python_requires='>=3.5',
     packages=packages,
+    test_suite='nose.collector',
+    tests_require=['nose'],
 )


### PR DESCRIPTION
`python setup.py test` is a conventional way to run tests, and now
works.