### PR TITLE
Mark PPC64 GPR12 for entry point initialization

### DIFF
--- a/archinfo/arch_ppc64.py
+++ b/archinfo/arch_ppc64.py
@@ -131,7 +131,7 @@ class ArchPPC64(Arch):
         Register(name='gpr11', size=8, alias_names=('r11',),
                  general_purpose=True),
         Register(name='gpr12', size=8, alias_names=('r12',),
-                 general_purpose=True),
+                 general_purpose=True, linux_entry_value='entry'),
         Register(name='gpr13', size=8, alias_names=('r13',),
                  general_purpose=True),
         Register(name='gpr14', size=8, alias_names=('r14',),


### PR DESCRIPTION
According to [PPC64 ABIv2](http://openpowerfoundation.org/wp-content/uploads/resources/leabi/content/dbdoclet.50655242___RefHeading___Toc377640653.html), R12 should be initialized to the address of the first function being invoked. This patch marks the register to be initialized with the entry point address.

~~This will also require a PR to angr which I plan to file shortly.~~ This is a companion PR to [angr#1870](https://github.com/angr/angr/pull/1870). It can be merged safely without that PR, but will generate a warning on initialization.