### PR TITLE
Use find(1) in a more portable way

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     from distutils.core import setup
     import os
-    packages = [x.strip('./').replace('/','.') for x in os.popen('find -name "__init__.py" | xargs -n1 dirname').read().strip().split('\n')]
+    packages = [x.strip('./').replace('/','.') for x in os.popen('find . -name "__init__.py" | xargs -n1 dirname').read().strip().split('\n')]
 
 if bytes is str:
     raise Exception("This module is designed for python 3 only. Please install an older version to use python 2.")


### PR DESCRIPTION
Not all find(1) implementation allow the user to skip
the directory on the command-line.