### PR TITLE
Remove type aliases.

### DIFF
--- a/archinfo/__init__.py
+++ b/archinfo/__init__.py
@@ -8,13 +8,7 @@ __version__ = (8, 20, 1, 7)
 if bytes is str:
     raise Exception("This module is designed for python 3 only. Please install an older version to use python 2.")
 
-# Type Aliases
-from typing import NewType
-RegisterOffset = NewType('RegisterOffset', int)
-RegisterName = NewType('RegisterName', str)
-TmpVar = NewType('TmpVar', int)
-
-# pylint: disable=wildcard-import
+# pylint:disable=wildcard-import
 from .arch import *
 from .defines import defines
 from .arch_amd64    import ArchAMD64

--- a/archinfo/arch.py
+++ b/archinfo/arch.py
@@ -5,7 +5,6 @@ import platform as _platform
 import re
 
 from .archerror import ArchError
-from . import RegisterOffset, RegisterName
 from .tls import TLSArchInfo
 
 import copy
@@ -78,11 +77,11 @@ class Register:
                  vector=False, argument=False, persistent=False, default_value=None,
                  linux_entry_value=None, concretize_unique=False, concrete=True,
                  artificial=False):
-        self.name = name # type: RegisterName
-        self.size = size # type: int
-        self.vex_offset = vex_offset # type: RegisterOffset
-        self.vex_name = vex_name
-        self.subregisters = [] if subregisters is None else subregisters # type: List[Tuple[RegisterName, RegisterOffset, int]]
+        self.name = name  # type: str
+        self.size = size  # type: int
+        self.vex_offset = vex_offset  # type: int
+        self.vex_name = vex_name  # type: str
+        self.subregisters = [] if subregisters is None else subregisters # type: List[Tuple[str, int, int]]
         self.alias_names = () if alias_names is None else alias_names
         self.general_purpose = general_purpose
         self.floating_point = floating_point
@@ -368,7 +367,7 @@ class Arch:
 
         return fmt_end + fmt_size
 
-    def _get_register_dict(self) ->  Dict[RegisterName, Tuple[RegisterOffset, int]]:
+    def _get_register_dict(self) ->  Dict[str, Tuple[int, int]]:
         res = {}
         for r in self.register_list:
             if r.vex_offset is None:
@@ -645,11 +644,11 @@ class Arch:
     instruction_alignment = None
 
     # register ofsets
-    ip_offset = None # type: RegisterOffset
-    sp_offset = None # type: RegisterOffset
-    bp_offset = None # type: RegisterOffset
-    ret_offset = None # type: RegisterOffset
-    lr_offset = None # type: RegisterOffset
+    ip_offset = None # type: int
+    sp_offset = None # type: int
+    bp_offset = None # type: int
+    ret_offset = None # type: int
+    lr_offset = None # type: int
 
     # whether or not VEX has ccall handlers for conditionals for this arch
     vex_conditional_helpers = False


### PR DESCRIPTION
According to [mypy](https://mypy.readthedocs.io/en/stable/more_types.html#newtypes), `NewType`s must be explicitly stated at casting. As a result, with type aliases, we would have to use `RegisterName("rax")` instead of just `"rax"`, which is obviously not ideal. Getting rid of type aliases to make both developers and mypy happy.