### PR TITLE
Type aliasing

### DIFF
--- a/archinfo/__init__.py
+++ b/archinfo/__init__.py
@@ -8,7 +8,13 @@ __version__ = (8, 20, 1, 7)
 if bytes is str:
     raise Exception("This module is designed for python 3 only. Please install an older version to use python 2.")
 
-# pylint:disable=wildcard-import
+# Type Aliases
+from typing import NewType
+RegisterOffset = NewType('RegisterOffset', int)
+RegisterName = NewType('RegisterName', str)
+TmpVar = NewType('TmpVar', int)
+
+# pylint: disable=wildcard-import
 from .arch import *
 from .defines import defines
 from .arch_amd64    import ArchAMD64

--- a/archinfo/__init__.py
+++ b/archinfo/__init__.py
@@ -8,11 +8,17 @@ __version__ = (8, 20, 1, 7)
 if bytes is str:
     raise Exception("This module is designed for python 3 only. Please install an older version to use python 2.")
 
-# Type Aliases
+# NewType Declaration, see https://docs.python.org/3/library/typing.html#newtype
 from typing import NewType
 RegisterOffset = NewType('RegisterOffset', int)
-RegisterName = NewType('RegisterName', str)
 TmpVar = NewType('TmpVar', int)
+
+# This causes too much issues as a NewType, sot is a simple alias instead
+# This means that is still legal to pass any str where a RegisterName is expected.
+# The downside is that PyCharm will show the type as `str` when displaying the signature
+RegisterName = str
+
+
 
 # pylint: disable=wildcard-import
 from .arch import *

--- a/archinfo/arch.py
+++ b/archinfo/arch.py
@@ -5,6 +5,7 @@ import platform as _platform
 import re
 
 from .archerror import ArchError
+from . import RegisterOffset, RegisterName
 from .tls import TLSArchInfo
 
 import copy
@@ -77,11 +78,11 @@ class Register:
                  vector=False, argument=False, persistent=False, default_value=None,
                  linux_entry_value=None, concretize_unique=False, concrete=True,
                  artificial=False):
-        self.name = name  # type: str
-        self.size = size  # type: int
-        self.vex_offset = vex_offset  # type: int
-        self.vex_name = vex_name  # type: str
-        self.subregisters = [] if subregisters is None else subregisters # type: List[Tuple[str, int, int]]
+        self.name = name # type: RegisterName
+        self.size = size # type: int
+        self.vex_offset = vex_offset # type: RegisterOffset
+        self.vex_name = vex_name
+        self.subregisters = [] if subregisters is None else subregisters # type: List[Tuple[RegisterName, RegisterOffset, int]]
         self.alias_names = () if alias_names is None else alias_names
         self.general_purpose = general_purpose
         self.floating_point = floating_point
@@ -367,7 +368,7 @@ class Arch:
 
         return fmt_end + fmt_size
 
-    def _get_register_dict(self) ->  Dict[str, Tuple[int, int]]:
+    def _get_register_dict(self) ->  Dict[RegisterName, Tuple[RegisterOffset, int]]:
         res = {}
         for r in self.register_list:
             if r.vex_offset is None:
@@ -644,11 +645,11 @@ class Arch:
     instruction_alignment = None
 
     # register ofsets
-    ip_offset = None # type: int
-    sp_offset = None # type: int
-    bp_offset = None # type: int
-    ret_offset = None # type: int
-    lr_offset = None # type: int
+    ip_offset = None # type: RegisterOffset
+    sp_offset = None # type: RegisterOffset
+    bp_offset = None # type: RegisterOffset
+    ret_offset = None # type: RegisterOffset
+    lr_offset = None # type: RegisterOffset
 
     # whether or not VEX has ccall handlers for conditionals for this arch
     vex_conditional_helpers = False

--- a/archinfo/arch.py
+++ b/archinfo/arch.py
@@ -654,7 +654,7 @@ class Arch:
     vex_conditional_helpers = False
 
     # memory stuff
-    bits = None  # type: int
+    bits = None
     memory_endness = Endness.LE
     register_endness = Endness.LE
     stack_change = None
@@ -697,8 +697,8 @@ class Arch:
     default_register_values = []
     entry_register_values = {}
     default_symbolic_registers = []
-    registers = {}  # type: Dict[str, Tuple[int, int]]
-    register_names = {}  # type: Dict[int, str]
+    registers = {} # type:  Dict[RegisterName, Tuple[RegisterOffset, int]]
+    register_names = {} # type: Dict[RegisterOffset, RegisterName]
     argument_registers = set()
     argument_register_positions = {}
     persistent_regs = []


### PR DESCRIPTION
As discussed on Slack. Relates to

`NewType` [0] types for `RegisterOffset` and `TmpVar` should not be an issue because they should nearly never be used by just using an integer literal and instead should be the result of some function or from some datastructure anyway. If this function or datastructure is properly typed this will not cause type issues and this will typically only be required in very few places and then propagate.

RegisterName is a different issue because just writing the string `"rax"` or similar will still be fairly common  and having to write it as `RegisterName("rax")` to satisfy the type checker quickly becomes annoying and causes more issues than it solves. Instead Type Aliases[1] can be used, which still allow `RegisterName` to be used for annotating functions and datastructures, but `str` can be used interchangeably with `RegisterName` (because it is the same object anyway). If it is deemed preferable to use a NewType instead at any point in the future, it will be a simple one line change back to `RegisterName = NewType("Registername", str)`

[0] https://docs.python.org/3/library/typing.html#newtype
[1] https://docs.python.org/3/library/typing.html#type-aliases