### PR TITLE
Mark emnote as an artificial register in all architectures

### DIFF
--- a/archinfo/arch_aarch64.py
+++ b/archinfo/arch_aarch64.py
@@ -303,7 +303,7 @@ class ArchAArch64(Arch):
                                                     ('b31', 0, 1)],
                  alias_names=('v31',), floating_point=True, vector=True),
         Register(name='qcflag', size=16, floating_point=True),
-        Register(name='emnote', size=4),
+        Register(name='emnote', size=4, artificial=True),
         Register(name='cmstart', size=8),
         Register(name='cmlen', size=8),
         Register(name='nraddr', size=8),

--- a/archinfo/arch_amd64.py
+++ b/archinfo/arch_amd64.py
@@ -337,7 +337,7 @@ class ArchAMD64(Arch):
                  floating_point=True, default_value=(0, False, None)),
         Register(name='fpround', size=8, floating_point=True, default_value=(0, False, None)),
         Register(name='fc3210', size=8, floating_point=True),
-        Register(name='emnote', size=4),
+        Register(name='emnote', size=4, artificial=True),
         Register(name='cmstart', size=8),
         Register(name='cmlen', size=8),
         Register(name='nraddr', size=8),

--- a/archinfo/arch_mips32.py
+++ b/archinfo/arch_mips32.py
@@ -179,7 +179,7 @@ class ArchMIPS32(Arch):
         Register(name='fenr', size=4, floating_point=True),
         Register(name='fcsr', size=4, floating_point=True),
         Register(name='ulr', size=4),
-        Register(name='emnote', size=4),
+        Register(name='emnote', size=4, artificial=True),
         Register(name='cmstart', size=4),
         Register(name='cmlen', size=4),
         Register(name='nraddr', size=4),

--- a/archinfo/arch_mips64.py
+++ b/archinfo/arch_mips64.py
@@ -175,7 +175,7 @@ class ArchMIPS64(Arch):
         Register(name='fcsr', size=4, floating_point=True),
         Register(name='cp0_status', size=4),
         Register(name='ulr', size=8),
-        Register(name='emnote', size=4),
+        Register(name='emnote', size=4, artificial=True),
         Register(name='cond', size=4),
         Register(name='cmstart', size=8),
         Register(name='cmlen', size=8),

--- a/archinfo/arch_ppc32.py
+++ b/archinfo/arch_ppc32.py
@@ -269,7 +269,7 @@ class ArchPPC32(Arch):
         Register(name='c_fpcc', size=1, floating_point=True),
         Register(name='vrsave', size=4, vector=True),
         Register(name='vscr', size=4, vector=True),
-        Register(name='emnote', size=4),
+        Register(name='emnote', size=4, artificial=True),
         Register(name='cmstart', size=4),
         Register(name='cmlen', size=4),
         Register(name='nraddr', size=4),

--- a/archinfo/arch_ppc64.py
+++ b/archinfo/arch_ppc64.py
@@ -294,7 +294,7 @@ class ArchPPC64(Arch):
         Register(name='c_fpcc', size=1, floating_point=True),
         Register(name='vrsave', size=4, vector=True),
         Register(name='vscr', size=4, vector=True),
-        Register(name='emnote', size=4),
+        Register(name='emnote', size=4, artificial=True),
         Register(name='cmstart', size=8),
         Register(name='cmlen', size=8),
         Register(name='nraddr', size=8),

--- a/archinfo/arch_s390x.py
+++ b/archinfo/arch_s390x.py
@@ -180,7 +180,7 @@ class ArchS390X(Arch):
         Register(name='cmstart', size=8),
         Register(name='cmlen', size=8),
         Register(name='ip_at_syscall', size=8, artificial=True),
-        Register(name='emnote', size=4),
+        Register(name='emnote', size=4, artificial=True),
     ]
 
     function_prologs = {

--- a/archinfo/arch_x86.py
+++ b/archinfo/arch_x86.py
@@ -228,7 +228,7 @@ class ArchX86(Arch):
         Register(name='ss', size=2),
         Register(name='ldt', size=8, default_value=(0, False, None), concrete=False),
         Register(name='gdt', size=8, default_value=(0, False, None), concrete=False),
-        Register(name='emnote', size=4),
+        Register(name='emnote', size=4, artificial=True),
         Register(name='cmstart', size=4),
         Register(name='cmlen', size=4),
         Register(name='nraddr', size=4),


### PR DESCRIPTION
emnote is marked artificial only in ARM. This PR marks it as artificial in other architectures too.