### PR TITLE
Moved register mappings needed by new unicorn engine from unicorn state plugin

### DIFF
--- a/archinfo/arch_amd64.py
+++ b/archinfo/arch_amd64.py
@@ -60,6 +60,8 @@ class ArchAMD64(Arch):
             self.registers['xmm6'][0]: 6,
             self.registers['xmm7'][0]: 7
         } if _pyvex is not None else None
+        if _unicorn:
+            self.unicorn_flag_register = _unicorn.x86_const.UC_X86_REG_EFLAGS
 
     @property
     def capstone_x86_syntax(self):

--- a/archinfo/arch_x86.py
+++ b/archinfo/arch_x86.py
@@ -49,6 +49,9 @@ class ArchX86(Arch):
         if self.vex_archinfo:
             self.vex_archinfo['x86_cr0'] = 0xFFFFFFFF
 
+        if _unicorn:
+            self.unicorn_flag_register = _unicorn.x86_const.UC_X86_REG_EFLAGS
+
     @property
     def capstone_x86_syntax(self):
         """


### PR DESCRIPTION
This PR adds all the register mappings needed by the new unicorn engine for taint propagation. These were originally present in the unicorn state plugin in angr code but archinfo is probably a better place for them.