### PR TITLE
Mark ftop register as an artificial register on x86 and amd64

### DIFF
--- a/archinfo/arch_amd64.py
+++ b/archinfo/arch_amd64.py
@@ -325,7 +325,7 @@ class ArchAMD64(Arch):
                                                       ('xmm15hq', 8, 8),
                                                       ('ymm15hx', 16, 16)],
                  vector=True),
-        Register(name='ftop', size=4, floating_point=True, default_value=(0, False, None)),
+        Register(name='ftop', size=4, floating_point=True, default_value=(0, False, None), artificial=True),
         Register(name='fpreg', size=64, subregisters=[('mm0', 0, 8),
                                                       ('mm1', 8, 8),
                                                       ('mm2', 16, 8),

--- a/archinfo/arch_x86.py
+++ b/archinfo/arch_x86.py
@@ -212,7 +212,7 @@ class ArchX86(Arch):
                  default_value=(0, False, None)),
         Register(name='fc3210', size=4, floating_point=True),
         Register(name='ftop', size=4, floating_point=True,
-                 default_value=(0, False, None)),
+                 default_value=(0, False, None), artificial=True),
         Register(name='sseround', size=4, vector=True,
                  default_value=(0, False, None)),
         Register(name='xmm0', size=16, vector=True),


### PR DESCRIPTION
ftop register should be an artificial register on x86 and amd64: it's used to store index of the register that is currently the top of the FP stack.