### PR TITLE
Fixes for subregister handling in unicorn engine

### DIFF
--- a/archinfo/arch.py
+++ b/archinfo/arch.py
@@ -302,6 +302,8 @@ class Arch:
                         self.vex_reg_offset_to_name[vex_sub_reg_offset] = (reg_name, vex_reg.size)
 
                     self.vex_sub_reg_to_reg_map[vex_sub_reg_offset] = vex_reg.vex_offset
+                    if vex_sub_reg_offset not in self.vex_reg_to_size_map:
+                        self.vex_reg_to_size_map[vex_sub_reg_offset] = vex_sub_reg[2]
 
             # CPU flag registers
             cpu_flag_registers = {'d': 10, 'ac': 18, 'id': 21}


### PR DESCRIPTION
Changes to archinfo data would be needed to support changes in subregister tainting in unicorn engine. This PR stores size of subregisters whose start offsets are different from that of their full register. The failing pyvex test case also fails on master so it is likely unrelated to this change. I setup a full CI environment of master as described [here](https://github.com/angr/ci-settings) and tested there.

A related PR removing some features that are no longer required will follow in future. I will create that PR after the subregister tainting code in unicorn engine is merged into angr master so that the CI doesn't break.