### PR TITLE
x86/amd64: Fixed default value of FTOP

### DIFF
--- a/archinfo/arch_amd64.py
+++ b/archinfo/arch_amd64.py
@@ -325,7 +325,7 @@ class ArchAMD64(Arch):
                                                       ('xmm15hq', 8, 8),
                                                       ('ymm15hx', 16, 16)],
                  vector=True),
-        Register(name='ftop', size=4, floating_point=True, default_value=(0, False, None), artificial=True),
+        Register(name='ftop', size=4, floating_point=True, default_value=(7, False, None), artificial=True),
         Register(name='fpreg', size=64, subregisters=[('mm0', 0, 8),
                                                       ('mm1', 8, 8),
                                                       ('mm2', 16, 8),

--- a/archinfo/arch_x86.py
+++ b/archinfo/arch_x86.py
@@ -212,7 +212,7 @@ class ArchX86(Arch):
                  default_value=(0, False, None)),
         Register(name='fc3210', size=4, floating_point=True),
         Register(name='ftop', size=4, floating_point=True,
-                 default_value=(0, False, None), artificial=True),
+                 default_value=(7, False, None), artificial=True),
         Register(name='sseround', size=4, vector=True,
                  default_value=(0, False, None)),
         Register(name='xmm0', size=16, vector=True),


### PR DESCRIPTION
According to the Intel software developers manual, the floating point register stack grows towards offset 0. At start of execution, the stack would be empty and so default value of FTOP should be 7 instead of 0.