### PR TITLE
Moved x86/amd64 specific setup code to arch specific files

### DIFF
--- a/archinfo/arch.py
+++ b/archinfo/arch.py
@@ -266,15 +266,6 @@ class Arch:
                 if hasattr(self.uc_const, reg_name):
                     self.uc_regs[r] = getattr(self.uc_const, reg_name)
 
-            # Register blacklist
-            reg_blacklist = ('cs', 'ds', 'es', 'fs', 'gs', 'ss', 'mm0', 'mm1', 'mm2', 'mm3', 'mm4', 'mm5', 'mm6', 'mm7', 'gdt', 'ldt')
-            self.reg_blacklist = []
-            self.reg_blacklist_offsets = []
-            for register in self.register_list:
-                if register.name in reg_blacklist:
-                    self.reg_blacklist.append(register.name)
-                    self.reg_blacklist_offsets.append(register.vex_offset)
-
             # Artificial registers offsets
             self.artificial_registers_offsets = []
             for reg_name in self.artificial_registers:
@@ -290,16 +281,6 @@ class Arch:
 
                 vex_reg = self.get_register_by_name(reg_name)
                 self.vex_to_unicorn_map[vex_reg.vex_offset] = unicorn_reg_id
-
-            # CPU flag registers
-            cpu_flag_registers = {'d': 10, 'ac': 18, 'id': 21}
-            self.cpu_flag_register_offsets_and_bitmasks_map = {}
-            for flag_reg, bitmask in cpu_flag_registers.items():
-                if flag_reg in self.registers:
-                    flag_reg_offset = self.get_register_offset(flag_reg)
-                    flag_bitmask = (1 << bitmask)
-                    self.cpu_flag_register_offsets_and_bitmasks_map[flag_reg_offset] = flag_bitmask
-
 
     def copy(self):
         """

--- a/archinfo/arch_amd64.py
+++ b/archinfo/arch_amd64.py
@@ -63,6 +63,24 @@ class ArchAMD64(Arch):
         if _unicorn:
             self.unicorn_flag_register = _unicorn.x86_const.UC_X86_REG_EFLAGS
 
+        # Register blacklist
+        reg_blacklist = ('fs', 'gs')
+        self.reg_blacklist = []
+        self.reg_blacklist_offsets = []
+        for register in self.register_list:
+            if register.name in reg_blacklist:
+                self.reg_blacklist.append(register.name)
+                self.reg_blacklist_offsets.append(register.vex_offset)
+
+        # CPU flag registers
+        cpu_flag_registers = {'d': 10, 'ac': 18, 'id': 21}
+        self.cpu_flag_register_offsets_and_bitmasks_map = {}
+        for flag_reg, bitmask in cpu_flag_registers.items():
+            if flag_reg in self.registers:
+                flag_reg_offset = self.get_register_offset(flag_reg)
+                flag_bitmask = (1 << bitmask)
+                self.cpu_flag_register_offsets_and_bitmasks_map[flag_reg_offset] = flag_bitmask
+
     @property
     def capstone_x86_syntax(self):
         """

--- a/archinfo/arch_x86.py
+++ b/archinfo/arch_x86.py
@@ -52,6 +52,24 @@ class ArchX86(Arch):
         if _unicorn:
             self.unicorn_flag_register = _unicorn.x86_const.UC_X86_REG_EFLAGS
 
+        # Register blacklist
+        reg_blacklist = ('cs', 'ds', 'es', 'fs', 'gs', 'ss', 'gdt', 'ldt')
+        self.reg_blacklist = []
+        self.reg_blacklist_offsets = []
+        for register in self.register_list:
+            if register.name in reg_blacklist:
+                self.reg_blacklist.append(register.name)
+                self.reg_blacklist_offsets.append(register.vex_offset)
+
+        # CPU flag registers
+        cpu_flag_registers = {'d': 10, 'ac': 18, 'id': 21}
+        self.cpu_flag_register_offsets_and_bitmasks_map = {}
+        for flag_reg, bitmask in cpu_flag_registers.items():
+            if flag_reg in self.registers:
+                flag_reg_offset = self.get_register_offset(flag_reg)
+                flag_bitmask = (1 << bitmask)
+                self.cpu_flag_register_offsets_and_bitmasks_map[flag_reg_offset] = flag_bitmask
+
     @property
     def capstone_x86_syntax(self):
         """


### PR DESCRIPTION
The register blacklist and CPU flags setup code is x86/amd64 specific and should not be in arch.py but in arch_x86.py/arch_amd64.py. I am not sure why CI runner 8 timed out: the last run test from angrop completed in 2 minutes locally.