### PR TITLE
Change default values to make iteration play nice.

### DIFF
--- a/archinfo/arch.py
+++ b/archinfo/arch.py
@@ -708,8 +708,8 @@ class Arch:
     artificial_registers_offsets = None
     artificial_registers = set()
     cpu_flag_register_offsets_and_bitmasks_map = None
-    reg_blacklist = None
-    reg_blacklist_offsets = None
+    reg_blacklist = []
+    reg_blacklist_offsets = []
     unicorn_flag_register = None
     vex_to_unicorn_map = None
     vex_cc_regs = None

--- a/archinfo/arch_amd64.py
+++ b/archinfo/arch_amd64.py
@@ -65,8 +65,6 @@ class ArchAMD64(Arch):
 
         # Register blacklist
         reg_blacklist = ('fs', 'gs')
-        self.reg_blacklist = []
-        self.reg_blacklist_offsets = []
         for register in self.register_list:
             if register.name in reg_blacklist:
                 self.reg_blacklist.append(register.name)

--- a/archinfo/arch_x86.py
+++ b/archinfo/arch_x86.py
@@ -54,8 +54,6 @@ class ArchX86(Arch):
 
         # Register blacklist
         reg_blacklist = ('cs', 'ds', 'es', 'fs', 'gs', 'ss', 'gdt', 'ldt')
-        self.reg_blacklist = []
-        self.reg_blacklist_offsets = []
         for register in self.register_list:
             if register.name in reg_blacklist:
                 self.reg_blacklist.append(register.name)


### PR DESCRIPTION
Fixes an issue when running Symbion on ARM architectures with Unicorn enabled:

```
File "/home/[...snip...]/angr/state_plugins/unicorn_engine.py", line 1259, in set_regs
    if r in self.state.arch.reg_blacklist:
TypeError: argument of type 'NoneType' is not iterable
```

[x86](https://github.com/angr/archinfo/blob/bd84450115db29bef89022e3c63c7ea84facd46e/archinfo/arch_x86.py#L57) and [x86_64](https://github.com/angr/archinfo/blob/bd84450115db29bef89022e3c63c7ea84facd46e/archinfo/arch_amd64.py#L68) already initialize these to empty list.