### PR TITLE
Store register size with the VEX register offset to unicorn register ID mapping

### DIFF
--- a/archinfo/arch.py
+++ b/archinfo/arch.py
@@ -280,7 +280,7 @@ class Arch:
                     continue
 
                 vex_reg = self.get_register_by_name(reg_name)
-                self.vex_to_unicorn_map[vex_reg.vex_offset] = unicorn_reg_id
+                self.vex_to_unicorn_map[vex_reg.vex_offset] = (unicorn_reg_id, vex_reg.size)
 
             # VEX registers used in lieu of flags register
             self.vex_cc_regs = []


### PR DESCRIPTION
This PR modifies archinfo to store the size of the register along with VEX register offset to unicorn register ID mapping. The size info will be used in angr's native interface.

This PR also depends on angr/angr#3131. The test case failures are because of this dependency. I ran all CI tests locally with the changes in the two PRs and did not find any failing tests.