### PR TITLE
Rewrote CPU flags handling: enable supporting multiple 'flag' style values

### DIFF
--- a/archinfo/arch.py
+++ b/archinfo/arch.py
@@ -707,10 +707,9 @@ class Arch:
     uc_regs = None
     artificial_registers_offsets = None
     artificial_registers = set()
-    cpu_flag_register_offsets_and_bitmasks_map = None
+    cpu_flag_register_offsets_and_bitmasks_map = {}
     reg_blacklist = []
     reg_blacklist_offsets = []
-    unicorn_flag_register = None
     vex_to_unicorn_map = None
     vex_cc_regs = None
 


### PR DESCRIPTION
This PR modifies archinfo to support multiple "flag" style values stored in larger registers. This info will be used in angr's native interface.

This PR also depends on angr/angr#3134. The test case failures are because of this dependency. I ran all CI tests locally with the changes in the two PRs and did not find any failing tests.