### PR TITLE
AARCH64: Fixed inconsistent capitalization for AARCH64

### DIFF
--- a/archinfo/arch_arm.py
+++ b/archinfo/arch_arm.py
@@ -25,7 +25,7 @@ from .tls import TLSArchInfo
 # TODO: which endianness should be default?
 
 def is_arm_arch(a):
-    return a.name.startswith('ARM') or a.name.startswith("AArch")
+    return a.name.startswith('ARM') or a.name.startswith("AARCH")
 
 def get_real_address_if_arm(arch, addr):
     """


### PR DESCRIPTION
The arch name of AARCH64 is capitalized in arch_aarch64.py, so the function is_arm_arch incorrectly returns False for AARCH64 binaries, thus causing some analyses in angr work improperly.