### PR TITLE
Fix: Get Register object via subregister name

### DIFF
--- a/archinfo/arch.py
+++ b/archinfo/arch.py
@@ -363,7 +363,7 @@ class Arch:
         on an ARM platform.
         """
         for r in self.register_list:
-            if reg_name == r.name or reg_name in r.alias_names:
+            if reg_name == r.name or reg_name in r.alias_names or reg_name in [sub_reg[0] for sub_reg in r.subregisters]:
                 return r
         return None
 

--- a/archinfo/arch.py
+++ b/archinfo/arch.py
@@ -363,7 +363,11 @@ class Arch:
         on an ARM platform.
         """
         for r in self.register_list:
-            if reg_name == r.name or reg_name in r.alias_names or reg_name in [sub_reg[0] for sub_reg in r.subregisters]:
+            if (
+                reg_name == r.name
+                or reg_name in r.alias_names
+                or reg_name in [sub_reg[0] for sub_reg in r.subregisters]
+            ):
                 return r
         return None
 


### PR DESCRIPTION
The feature was mentioned in the comment, but never implemented.
https://github.com/angr/archinfo/blob/55ba856a57fc813913678a4920ada45d621595fa/archinfo/arch.py#L358