### PR TITLE
Added function to check for RISCV architecture

### DIFF
--- a/archinfo/arch_riscv64.py
+++ b/archinfo/arch_riscv64.py
@@ -17,6 +17,8 @@ try:
 except ImportError:
     _unicorn = None
 
+def is_riscv_arch(a):
+    return a.name.startswith("RISCV")
 
 class ArchRISCV64(Arch):
     def __init__(self, endness=Endness.LE):

--- a/archinfo/arch_riscv64.py
+++ b/archinfo/arch_riscv64.py
@@ -17,8 +17,10 @@ try:
 except ImportError:
     _unicorn = None
 
+
 def is_riscv_arch(a):
     return a.name.startswith("RISCV")
+
 
 class ArchRISCV64(Arch):
     def __init__(self, endness=Endness.LE):


### PR DESCRIPTION
The added function checks that RISCV architecture is used in this PR: https://github.com/angr/angr/pull/4073. 
In the implementation of one of the VEX statement handlers for Dirty statements, we use the function to check that RISCV architecture is used: https://github.com/angr/angr/pull/4073/commits/b22bdfe3d4e8b28d9f176398a6c2ad1e50c84ff1.