### PR TITLE
Test CI with python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   ci:
     uses: angr/ci-settings/.github/workflows/angr-ci.yml@master
+    with:
+      container_image: angr/ci:jammy
   windows:
     uses: ./.github/workflows/windows.yml
   macos:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.10"
       - run: python -m venv $HOME/venv
         name: Create venv
         shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.10"
       - run: python -m venv $HOME/venv
         name: Create venv
         shell: bash


### PR DESCRIPTION
Ubuntu 24.04 is scheduled for release on 4/25/24. At that time angr will be dropping support for python <3.10, this PR is for me to test that we're ready for that.