### PR TITLE
AMD64: Add new PLT dynamic array tags

### DIFF
--- a/archinfo/arch_amd64.py
+++ b/archinfo/arch_amd64.py
@@ -447,6 +447,13 @@ class ArchAMD64(Arch):
         Register(name="ss_seg", size=2, vex_name="ss"),
     ]
 
+    # https://gitlab.com/x86-psABIs/x86-64-ABI
+    dynamic_tag_translation = {
+        0x70000000: "DT_X86_64_PLT",
+        0x70000001: "DT_X86_64_PLTSZ",
+        0x70000003: "DT_X86_64_PLTENT",
+    }
+
     symbol_type_translation = {10: "STT_GNU_IFUNC", "STT_LOOS": "STT_GNU_IFUNC"}
     got_section_name = ".got.plt"
     ld_linux_name = "ld-linux-x86-64.so.2"


### PR DESCRIPTION
Add new tags according to the x86-64 psABI [1]:

1. DT_LOPROC + 0 -> DT_X86_64_PLT: The address of the procedure linkage table.
2. DT_LOPROC + 1 -> DT_X86_64_PLTSZ: The total size, in bytes, of the procedure linkage table.
3. DT_LOPROC + 3 -> DT_X86_64_PLTENT: The size, in bytes, of a procedure linkage table entry. Always a power of 2.

1: https://gitlab.com/x86-psABIs/x86-64-ABI
2: See also https://sourceware.org/git/?p=glibc.git;a=commit;h=848746e88ec2aa22e8dea25f2110e2b2c59c712e

Fixes #217 