### PR TITLE
setup.cfg: spell dependency differently

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    backports.strenum>=1.2.8;python_version<'3.11'
+    backports-strenum>=1.2.8;python_version<'3.11'
 python_requires = >=3.10
 
 [options.extras_require]


### PR DESCRIPTION
absolutely asinine bug found on ubuntu 22 while using the angr cli

```
[+] ~/proj/angr/foo% angr decompile 05e96f707a16ab3398e8a88ee7a8b9e8f6dfbdec4f7b558cf201093e429b5a8f                                                                                                                                                                                                                                                                                                                                                                                [2824/3130]
Traceback (most recent call last):                                                                        
  File "/home/audrey/.virtualenvs/angr-c/bin/angr", line 33, in <module>                                  
    sys.exit(load_entry_point('angr', 'console_scripts', 'angr')())                                       
  File "/home/audrey/.virtualenvs/angr-c/bin/angr", line 25, in importlib_load_entry_point                
    return next(matches).load()                                                                           
  File "/usr/lib/python3.10/importlib/metadata/__init__.py", line 171, in load                            
    module = import_module(match.group('module'))                                                         
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module                            
    return _bootstrap._gcd_import(name[level:], package, level)                                           
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import                                         
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load                                      
  File "<frozen importlib._bootstrap>", line 992, in _find_and_load_unlocked                              
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed                            
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import                                         
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load                                      
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked                             
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked                                       
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module                                 
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed                            
  File "/home/audrey/proj/angr/angr/angr/__init__.py", line 40, in <module>                               
    from .sim_procedure import SimProcedure                                                               
  File "/home/audrey/proj/angr/angr/angr/sim_procedure.py", line 8, in <module>                           
    from cle import SymbolType                                                                            
  File "/home/audrey/proj/angr/cle/cle/__init__.py", line 13, in <module>                                 
    from .backends import (                                                                               
  File "/home/audrey/proj/angr/cle/cle/backends/__init__.py", line 3, in <module>                         
    from .backend import ALL_BACKENDS, Backend, ExceptionHandling, FunctionHint, FunctionHintSource, register_backend                                                                                                
  File "/home/audrey/proj/angr/cle/cle/backends/backend.py", line 9, in <module>                          
    import archinfo                                                                                       
  File "/home/audrey/proj/angr/archinfo/archinfo/__init__.py", line 10, in <module>                       
    from .arch import (                                                                                   
  File "/home/audrey/proj/angr/archinfo/archinfo/arch.py", line 23, in <module>                           
    import unicorn as _unicorn                                                                            
  File "/home/audrey/.virtualenvs/angr-c/lib/python3.10/site-packages/unicorn/__init__.py", line 4, in <module>                                                                                                      
    from .unicorn import Uc, uc_version, uc_arch_supported, version_bind, debug, UcError, __version__     
  File "/home/audrey/.virtualenvs/angr-c/lib/python3.10/site-packages/unicorn/unicorn.py", line 8, in <module>                                                                                                       
    import pkg_resources                                                                                  
  File "/home/audrey/.virtualenvs/angr-c/lib/python3.10/site-packages/pkg_resources/__init__.py", line 3673, in <module>                                                                                                                       
    def _initialize_master_working_set():                                                                 
  File "/home/audrey/.virtualenvs/angr-c/lib/python3.10/site-packages/pkg_resources/__init__.py", line 3656, in _call_aside                                                                                                                    
    f(*args, **kwargs)                                                                                                 
  File "/home/audrey/.virtualenvs/angr-c/lib/python3.10/site-packages/pkg_resources/__init__.py", line 3685, in _initialize_master_working_set                                                                                                                                    
    working_set = _declare_state('object', 'working_set', WorkingSet._build_master())                     
  File "/home/audrey/.virtualenvs/angr-c/lib/python3.10/site-packages/pkg_resources/__init__.py", line 661, in _build_master                                                                                                                   
    ws.require(__requires__)                                                                                                            
  File "/home/audrey/.virtualenvs/angr-c/lib/python3.10/site-packages/pkg_resources/__init__.py", line 1070, in require                                                                                              
    needed = self.resolve(parse_requirements(requirements))                                                            
  File "/home/audrey/.virtualenvs/angr-c/lib/python3.10/site-packages/pkg_resources/__init__.py", line 897, in resolve                                                                                               
    dist = self._resolve_dist(                                                                                                          
  File "/home/audrey/.virtualenvs/angr-c/lib/python3.10/site-packages/pkg_resources/__init__.py", line 938, in _resolve_dist                                                                                                                   
    raise DistributionNotFound(req, requirers)                                                                                          
pkg_resources.DistributionNotFound: The 'backports.strenum>=1.2.8' distribution was not found and is required by archinfo 
```