### PR TITLE
Disable unicorn from making a DeprecatedWarning print on the screen

### DIFF
--- a/archinfo/arch.py
+++ b/archinfo/arch.py
@@ -3,8 +3,8 @@ import logging
 import platform as _platform
 import re
 import struct as _struct
-from typing import Any, Dict, List, Optional, Set, Tuple, Type, Union
 import warnings
+from typing import Any, Dict, List, Optional, Set, Tuple, Type, Union
 
 from archinfo.types import RegisterName, RegisterOffset
 
@@ -14,6 +14,7 @@ from .types import Endness
 
 log = logging.getLogger("archinfo.arch")
 log.addHandler(logging.NullHandler())
+
 
 def warningless_import_unicorn():
     with warnings.catch_warnings():

--- a/archinfo/arch.py
+++ b/archinfo/arch.py
@@ -20,6 +20,7 @@ def warningless_import_unicorn():
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         warnings.warn("deprecated", DeprecationWarning)
+        # pylint: disable=import-outside-toplevel
         import unicorn as _unicorn
     return _unicorn
 

--- a/archinfo/arch.py
+++ b/archinfo/arch.py
@@ -31,7 +31,6 @@ except ImportError:
 
 try:
     _unicorn = warningless_import_unicorn()
-    from unicorn import riscv_const
 except ImportError:
     _unicorn = None
 

--- a/archinfo/arch.py
+++ b/archinfo/arch.py
@@ -4,6 +4,7 @@ import platform as _platform
 import re
 import struct as _struct
 from typing import Any, Dict, List, Optional, Set, Tuple, Type, Union
+import warnings
 
 from archinfo.types import RegisterName, RegisterOffset
 
@@ -14,13 +15,22 @@ from .types import Endness
 log = logging.getLogger("archinfo.arch")
 log.addHandler(logging.NullHandler())
 
+def warningless_import_unicorn():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        warnings.warn("deprecated", DeprecationWarning)
+        import unicorn as _unicorn
+    return _unicorn
+
+
 try:
     import pyvex as _pyvex
 except ImportError:
     _pyvex = None
 
 try:
-    import unicorn as _unicorn
+    _unicorn = warningless_import_unicorn()
+    from unicorn import riscv_const
 except ImportError:
     _unicorn = None
 

--- a/archinfo/arch_aarch64.py
+++ b/archinfo/arch_aarch64.py
@@ -1,6 +1,6 @@
 from archinfo.types import RegisterOffset
 
-from .arch import Arch, Endness, Register, register_arch
+from .arch import Arch, Endness, Register, register_arch, warningless_import_unicorn
 from .tls import TLSArchInfo
 
 try:
@@ -14,7 +14,7 @@ except ImportError:
     _keystone = None
 
 try:
-    import unicorn as _unicorn
+    _unicorn = warningless_import_unicorn()
 except ImportError:
     _unicorn = None
 

--- a/archinfo/arch_amd64.py
+++ b/archinfo/arch_amd64.py
@@ -1,6 +1,6 @@
 from archinfo.types import RegisterOffset
 
-from .arch import Arch, Endness, Register, register_arch
+from .arch import Arch, Endness, Register, register_arch, warningless_import_unicorn
 from .archerror import ArchError
 from .tls import TLSArchInfo
 
@@ -15,7 +15,7 @@ except ImportError:
     _keystone = None
 
 try:
-    import unicorn as _unicorn
+    _unicorn = warningless_import_unicorn()
 except ImportError:
     _unicorn = None
 

--- a/archinfo/arch_arm.py
+++ b/archinfo/arch_arm.py
@@ -2,7 +2,7 @@ import logging
 
 from archinfo.types import RegisterOffset
 
-from .arch import Arch, Endness, Register, register_arch
+from .arch import Arch, Endness, Register, register_arch, warningless_import_unicorn
 from .tls import TLSArchInfo
 
 log = logging.getLogger("archinfo.arch_arm")
@@ -18,7 +18,7 @@ except ImportError:
     _keystone = None
 
 try:
-    import unicorn as _unicorn
+    _unicorn = warningless_import_unicorn()
 except ImportError:
     _unicorn = None
 

--- a/archinfo/arch_mips32.py
+++ b/archinfo/arch_mips32.py
@@ -1,4 +1,4 @@
-from .arch import Arch, Endness, Register, register_arch
+from .arch import Arch, Endness, Register, register_arch, warningless_import_unicorn
 from .tls import TLSArchInfo
 
 try:
@@ -12,7 +12,7 @@ except ImportError:
     _keystone = None
 
 try:
-    import unicorn as _unicorn
+    _unicorn = warningless_import_unicorn()
 except ImportError:
     _unicorn = None
 

--- a/archinfo/arch_mips64.py
+++ b/archinfo/arch_mips64.py
@@ -1,6 +1,6 @@
 from archinfo.types import RegisterOffset
 
-from .arch import Arch, Endness, Register, register_arch
+from .arch import Arch, Endness, Register, register_arch, warningless_import_unicorn
 from .tls import TLSArchInfo
 
 try:
@@ -14,7 +14,7 @@ except ImportError:
     _keystone = None
 
 try:
-    import unicorn as _unicorn
+    _unicorn = warningless_import_unicorn()
 except ImportError:
     _unicorn = None
 

--- a/archinfo/arch_riscv64.py
+++ b/archinfo/arch_riscv64.py
@@ -1,6 +1,6 @@
 from archinfo.types import RegisterOffset
 
-from .arch import Arch, Endness, Register, register_arch
+from .arch import Arch, Endness, Register, register_arch, warningless_import_unicorn
 from .tls import TLSArchInfo
 
 try:
@@ -14,7 +14,7 @@ except ImportError:
     _keystone = None
 
 try:
-    import unicorn as _unicorn
+    _unicorn = warningless_import_unicorn()
     from unicorn import riscv_const
 except ImportError:
     _unicorn = None

--- a/archinfo/arch_x86.py
+++ b/archinfo/arch_x86.py
@@ -1,5 +1,3 @@
-import warnings
-
 from archinfo.types import RegisterOffset
 
 from .arch import Arch, Endness, Register, register_arch, warningless_import_unicorn

--- a/archinfo/arch_x86.py
+++ b/archinfo/arch_x86.py
@@ -1,6 +1,8 @@
+import warnings
+
 from archinfo.types import RegisterOffset
 
-from .arch import Arch, Endness, Register, register_arch
+from .arch import Arch, Endness, Register, register_arch, warningless_import_unicorn
 from .archerror import ArchError
 from .tls import TLSArchInfo
 
@@ -15,7 +17,7 @@ except ImportError:
     _keystone = None
 
 try:
-    import unicorn as _unicorn
+    _unicorn = warningless_import_unicorn()
 except ImportError:
     _unicorn = None
 


### PR DESCRIPTION
Unicorn will have the following Warning that prints on screen when importing:
```
UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
```

This disables that specific deprecation warning from printing.