### PR TITLE
AArch64: Add new PLT dynamic array tags

### DIFF
--- a/archinfo/arch_aarch64.py
+++ b/archinfo/arch_aarch64.py
@@ -397,6 +397,14 @@ class ArchAArch64(Arch):
         Register(name="fpcr", size=4, floating_point=True, default_value=(initial_sp, True, "global")),
     ]
 
+    dynamic_tag_translation = {
+        # https://github.com/ARM-software/abi-aa/blob/main/sysvabi64/sysvabi64.rst#dynamic-section-tags
+        # https://github.com/ARM-software/abi-aa/blob/main/aaelf64/aaelf64.rst#st-other-values
+        0x70000001: "DT_AARCH64_BTI_PLT",
+        0x70000003: "DT_AARCH64_PAC_PLT",
+        0x70000005: "DT_AARCH64_VARIANT_PCS",
+    }
+
     got_section_name = ".got"
     ld_linux_name = "ld-linux-aarch64.so.1"
     elf_tls = TLSArchInfo(1, 32, [], [0], [], 0, 0)

--- a/archinfo/arch_aarch64.py
+++ b/archinfo/arch_aarch64.py
@@ -412,6 +412,13 @@ class ArchAArch64(Arch):
         0x7000000C: "DT_AARCH64_MEMTAG_STACK",
         0x7000000D: "DT_AARCH64_MEMTAG_GLOBALS",
         0x7000000F: "DT_AARCH64_MEMTAG_GLOBALSSZ",
+
+        # https://github.com/ARM-software/abi-aa/blob/main/pauthabielf64/pauthabielf64.rst#dynamic-section
+        # These values are in the AArch64 Processor-specific range. The values are subject to change if 
+        # there is a clash with any section types added by AAELF64.
+        0x70000011: "DT_AARCH64_AUTH_RELRSZ",
+        0x70000012: "DT_AARCH64_AUTH_RELR",
+        0x70000013: "DT_AARCH64_AUTH_RELRENT",
     }
 
     got_section_name = ".got"

--- a/archinfo/arch_aarch64.py
+++ b/archinfo/arch_aarch64.py
@@ -403,6 +403,15 @@ class ArchAArch64(Arch):
         0x70000001: "DT_AARCH64_BTI_PLT",
         0x70000003: "DT_AARCH64_PAC_PLT",
         0x70000005: "DT_AARCH64_VARIANT_PCS",
+
+        # https://github.com/ARM-software/abi-aa/blob/main/memtagabielf64/memtagabielf64.rst#dynamic-section
+        # These values are in the AArch64 Processor-specific range. The values are subject to change if 
+        # there is a clash with any section types added by AAELF64.
+        0x70000009: "DT_AARCH64_MEMTAG_MODE",
+        0x7000000B: "DT_AARCH64_MEMTAG_HEAP",
+        0x7000000C: "DT_AARCH64_MEMTAG_STACK",
+        0x7000000D: "DT_AARCH64_MEMTAG_GLOBALS",
+        0x7000000F: "DT_AARCH64_MEMTAG_GLOBALSSZ",
     }
 
     got_section_name = ".got"

--- a/archinfo/arch_aarch64.py
+++ b/archinfo/arch_aarch64.py
@@ -403,18 +403,16 @@ class ArchAArch64(Arch):
         0x70000001: "DT_AARCH64_BTI_PLT",
         0x70000003: "DT_AARCH64_PAC_PLT",
         0x70000005: "DT_AARCH64_VARIANT_PCS",
-
         # https://github.com/ARM-software/abi-aa/blob/main/memtagabielf64/memtagabielf64.rst#dynamic-section
-        # These values are in the AArch64 Processor-specific range. The values are subject to change if 
+        # These values are in the AArch64 Processor-specific range. The values are subject to change if
         # there is a clash with any section types added by AAELF64.
         0x70000009: "DT_AARCH64_MEMTAG_MODE",
         0x7000000B: "DT_AARCH64_MEMTAG_HEAP",
         0x7000000C: "DT_AARCH64_MEMTAG_STACK",
         0x7000000D: "DT_AARCH64_MEMTAG_GLOBALS",
         0x7000000F: "DT_AARCH64_MEMTAG_GLOBALSSZ",
-
         # https://github.com/ARM-software/abi-aa/blob/main/pauthabielf64/pauthabielf64.rst#dynamic-section
-        # These values are in the AArch64 Processor-specific range. The values are subject to change if 
+        # These values are in the AArch64 Processor-specific range. The values are subject to change if
         # there is a clash with any section types added by AAELF64.
         0x70000011: "DT_AARCH64_AUTH_RELRSZ",
         0x70000012: "DT_AARCH64_AUTH_RELR",


### PR DESCRIPTION
Add new tags as outlined in the ARM sysvabi64 [[1](https://github.com/ARM-software/abi-aa/blob/main/sysvabi64/sysvabi64.rst#dynamic-section-tags)], memtagabielf64 [[2](https://github.com/ARM-software/abi-aa/blob/main/memtagabielf64/memtagabielf64.rst#dynamic-section)] and pauthabielf64 [[3](https://github.com/ARM-software/abi-aa/blob/main/pauthabielf64/pauthabielf64.rst#dynamic-section)] specs.

Fixes benign output seen during usage of tools with archinfo as a dependency e.g. during angrop analysis:
`ERROR | 2026-04-21 18:00:00,000 | archinfo.arch  | Please look up and add dynamic tag type 0x70000001 for AARCH64`

Note to whoever ends up reviewing; the memtagabielf64 spec outlines the following caveat/warning:
> "These values are in the AArch64 Processor-specific range. The values are subject to change if there is a clash with any section types added by [AAELF64](https://github.com/ARM-software/abi-aa/releases)." 

as such, it may be desirable to cherry-pick only the missing SysV ABI tags for merging (i.e. BTI/PAC/PCS) ?

## sysvabi64
DT_LOPROC + 1 -> DT_AARCH64_BTI_PLT: Indicates PLTs enabled with Branch Target Identification mechanism.
DT_LOPROC + 3 -> DT_AARCH64_PAC_PLT: Indicates PLTs enabled with Pointer Authentication.
DT_LOPROC + 5 -> DT_AARCH64_VARIANT_PCS: Indicates use of a variant Procedure Call Standard requiring non-standard calling conventions.

## memtagabielf64
DT_LOPROC + 9 -> DT_AARCH64_MEMTAG_MODE: Indicates initial Memory Tagging Extension mode (0: synchronous or 1: asynchronous).
DT_LOPROC + B -> DT_AARCH64_MEMTAG_HEAP: Indicates heap allocations should use memory tagging.
DT_LOPROC + C -> DT_AARCH64_MEMTAG_STACK: Indicates stack should be mapped with memory tagging support.
DT_LOPROC + D -> DT_AARCH64_MEMTAG_GLOBALS: Indicates global vars should be protected with memory tagging (points to tagged global variables metadata section).
DT_LOPROC + F -> DT_AARCH64_MEMTAG_GLOBALSSZ: Specifies size of the tagged globals metadata section.

## pauthabielf64
DT_LOPROC + 11 -> DT_AARCH64_AUTH_RELRSZ: Indicates the total size in bytes, of the authenticated RELR table.
DT_LOPROC + 12 -> DT_AARCH64_AUTH_RELR: Points to the authenticated RELR relocation table (`SHT_AARCH64_AUTH_RELR`).
DT_LOPROC + 13 -> DT_AARCH64_AUTH_RELRENT: Specifies size of each authenticated RELR relocation entry.

---

1: https://github.com/ARM-software/abi-aa/blob/main/sysvabi64/sysvabi64.rst#dynamic-section-tags
2: https://github.com/ARM-software/abi-aa/blob/main/memtagabielf64/memtagabielf64.rst#dynamic-section
3: https://github.com/ARM-software/abi-aa/blob/main/pauthabielf64/pauthabielf64.rst#dynamic-section