### PR TITLE
AMD64: Set fp_ret_offset

### DIFF
--- a/archinfo/arch_amd64.py
+++ b/archinfo/arch_amd64.py
@@ -152,6 +152,7 @@ class ArchAMD64(Arch):
     triplet = "x86_64-linux-gnu"
     max_inst_bytes = 15
     ret_offset = RegisterOffset(16)
+    fp_ret_offset = RegisterOffset(224)  # xmm0
     vex_conditional_helpers = True
     syscall_num_offset = 16
     call_pushes_ret = True


### PR DESCRIPTION
AMD64 SysV returns float/double in xmm0 (offset 224). Without this, the decompiler's AIL converter never created fp_ret_expr for call statements, so FP return values from calls were lost.