### PR TITLE
Add capstone 6 compatibility for ARM64 and S390X architectures

### DIFF
--- a/archinfo/arch_aarch64.py
+++ b/archinfo/arch_aarch64.py
@@ -48,7 +48,10 @@ class ArchAArch64(Arch):
     instruction_endness = Endness.LE
     sizeof = {"short": 16, "int": 32, "long": 64, "long long": 64}
     if _capstone:
-        cs_arch = getattr(_capstone, "CS_ARCH_AARCH64", _capstone.CS_ARCH_ARM64)
+        if hasattr(_capstone, "CS_ARCH_AARCH64"):
+            cs_arch = _capstone.CS_ARCH_AARCH64
+        else:
+            cs_arch = _capstone.CS_ARCH_ARM64
         cs_mode = _capstone.CS_MODE_LITTLE_ENDIAN
     if _keystone:
         ks_arch = _keystone.KS_ARCH_ARM64

--- a/archinfo/arch_aarch64.py
+++ b/archinfo/arch_aarch64.py
@@ -48,10 +48,7 @@ class ArchAArch64(Arch):
     instruction_endness = Endness.LE
     sizeof = {"short": 16, "int": 32, "long": 64, "long long": 64}
     if _capstone:
-        try:
-            cs_arch = _capstone.CS_ARCH_AARCH64
-        except AttributeError:
-            cs_arch = _capstone.CS_ARCH_ARM64
+        cs_arch = getattr(_capstone, "CS_ARCH_AARCH64", _capstone.CS_ARCH_ARM64)
         cs_mode = _capstone.CS_MODE_LITTLE_ENDIAN
     if _keystone:
         ks_arch = _keystone.KS_ARCH_ARM64

--- a/archinfo/arch_aarch64.py
+++ b/archinfo/arch_aarch64.py
@@ -48,7 +48,10 @@ class ArchAArch64(Arch):
     instruction_endness = Endness.LE
     sizeof = {"short": 16, "int": 32, "long": 64, "long long": 64}
     if _capstone:
-        cs_arch = _capstone.CS_ARCH_ARM64
+        try:
+            cs_arch = _capstone.CS_ARCH_AARCH64
+        except AttributeError:
+            cs_arch = _capstone.CS_ARCH_ARM64
         cs_mode = _capstone.CS_MODE_LITTLE_ENDIAN
     if _keystone:
         ks_arch = _keystone.KS_ARCH_ARM64

--- a/archinfo/arch_s390x.py
+++ b/archinfo/arch_s390x.py
@@ -57,7 +57,10 @@ class ArchS390X(Arch):
     initial_sp = 0x40000000000
     sizeof = {"short": 16, "int": 32, "long": 64, "long long": 64}
     if _capstone:
-        cs_arch = getattr(_capstone, "CS_ARCH_SYSTEMZ", _capstone.CS_ARCH_SYSZ)
+        if hasattr(_capstone, "CS_ARCH_SYSTEMZ"):
+            cs_arch = _capstone.CS_ARCH_SYSTEMZ
+        else:
+            cs_arch = _capstone.CS_ARCH_SYSZ
         cs_mode = _capstone.CS_MODE_BIG_ENDIAN
     if _keystone:
         ks_arch = _keystone.KS_ARCH_SYSTEMZ

--- a/archinfo/arch_s390x.py
+++ b/archinfo/arch_s390x.py
@@ -57,7 +57,10 @@ class ArchS390X(Arch):
     initial_sp = 0x40000000000
     sizeof = {"short": 16, "int": 32, "long": 64, "long long": 64}
     if _capstone:
-        cs_arch = _capstone.CS_ARCH_SYSZ
+        try:
+            cs_arch = _capstone.CS_ARCH_SYSTEMZ
+        except AttributeError:
+            cs_arch = _capstone.CS_ARCH_SYSZ
         cs_mode = _capstone.CS_MODE_BIG_ENDIAN
     if _keystone:
         ks_arch = _keystone.KS_ARCH_SYSTEMZ

--- a/archinfo/arch_s390x.py
+++ b/archinfo/arch_s390x.py
@@ -57,10 +57,7 @@ class ArchS390X(Arch):
     initial_sp = 0x40000000000
     sizeof = {"short": 16, "int": 32, "long": 64, "long long": 64}
     if _capstone:
-        try:
-            cs_arch = _capstone.CS_ARCH_SYSTEMZ
-        except AttributeError:
-            cs_arch = _capstone.CS_ARCH_SYSZ
+        cs_arch = getattr(_capstone, "CS_ARCH_SYSTEMZ", _capstone.CS_ARCH_SYSZ)
         cs_mode = _capstone.CS_MODE_BIG_ENDIAN
     if _keystone:
         ks_arch = _keystone.KS_ARCH_SYSTEMZ


### PR DESCRIPTION
Capstone 6 renamed CS_ARCH_ARM64 -> CS_ARCH_AARCH64 and CS_ARCH_SYSZ -> CS_ARCH_SYSTEMZ
in its Python bindings (old names removed entirely).

This adds try/except fallback so archinfo works with both capstone 5.x and 6.x.
The new constant name is tried first, with a fallback to the old name for older
capstone versions.
