### PR TITLE
Drop capstone <6.0 compat fallbacks and require capstone >=6.0

### DIFF
--- a/archinfo/arch_aarch64.py
+++ b/archinfo/arch_aarch64.py
@@ -48,10 +48,7 @@ class ArchAArch64(Arch):
     instruction_endness = Endness.LE
     sizeof = {"short": 16, "int": 32, "long": 64, "long long": 64}
     if _capstone:
-        if hasattr(_capstone, "CS_ARCH_AARCH64"):
-            cs_arch = _capstone.CS_ARCH_AARCH64
-        else:
-            cs_arch = _capstone.CS_ARCH_ARM64
+        cs_arch = _capstone.CS_ARCH_AARCH64
         cs_mode = _capstone.CS_MODE_LITTLE_ENDIAN
     if _keystone:
         ks_arch = _keystone.KS_ARCH_ARM64

--- a/archinfo/arch_riscv64.py
+++ b/archinfo/arch_riscv64.py
@@ -52,7 +52,7 @@ class ArchRISCV64(Arch):
     sizeof = {"short": 16, "int": 32, "long": 64, "long long": 64}
     if _capstone:
         cs_arch = _capstone.CS_ARCH_RISCV
-        cs_mode = _capstone.CS_MODE_RISCV64 | _capstone.CS_MODE_RISCVC
+        cs_mode = _capstone.CS_MODE_RISCV64 | getattr(_capstone, "CS_MODE_RISCVC", getattr(_capstone, "CS_MODE_RISCV_C", 0))
     # if _keystone:
     #     ks_arch = _keystone.KS_ARCH_RISCV
     #     ks_mode = _keystone.KS_MODE_LITTLE_ENDIAN

--- a/archinfo/arch_riscv64.py
+++ b/archinfo/arch_riscv64.py
@@ -50,7 +50,7 @@ class ArchRISCV64(Arch):
     register_endness = Endness.LE
     instruction_endness = Endness.LE
     sizeof = {"short": 16, "int": 32, "long": 64, "long long": 64}
-    if _capstone and hasattr(_capstone, "CS_ARCH_RISCV"):
+    if _capstone:
         cs_arch = _capstone.CS_ARCH_RISCV
         cs_mode = _capstone.CS_MODE_RISCV64 | _capstone.CS_MODE_RISCVC
     # if _keystone:

--- a/archinfo/arch_riscv64.py
+++ b/archinfo/arch_riscv64.py
@@ -52,7 +52,9 @@ class ArchRISCV64(Arch):
     sizeof = {"short": 16, "int": 32, "long": 64, "long long": 64}
     if _capstone:
         cs_arch = _capstone.CS_ARCH_RISCV
-        cs_mode = _capstone.CS_MODE_RISCV64 | getattr(_capstone, "CS_MODE_RISCVC", getattr(_capstone, "CS_MODE_RISCV_C", 0))
+        cs_mode = _capstone.CS_MODE_RISCV64 | getattr(
+            _capstone, "CS_MODE_RISCVC", getattr(_capstone, "CS_MODE_RISCV_C", 0)
+        )
     # if _keystone:
     #     ks_arch = _keystone.KS_ARCH_RISCV
     #     ks_mode = _keystone.KS_MODE_LITTLE_ENDIAN

--- a/archinfo/arch_s390x.py
+++ b/archinfo/arch_s390x.py
@@ -57,10 +57,7 @@ class ArchS390X(Arch):
     initial_sp = 0x40000000000
     sizeof = {"short": 16, "int": 32, "long": 64, "long long": 64}
     if _capstone:
-        if hasattr(_capstone, "CS_ARCH_SYSTEMZ"):
-            cs_arch = _capstone.CS_ARCH_SYSTEMZ
-        else:
-            cs_arch = _capstone.CS_ARCH_SYSZ
+        cs_arch = _capstone.CS_ARCH_SYSTEMZ
         cs_mode = _capstone.CS_MODE_BIG_ENDIAN
     if _keystone:
         ks_arch = _keystone.KS_ARCH_SYSTEMZ

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,9 @@ Homepage = "https://api.angr.io/projects/archinfo/en/latest/"
 Repository = "https://github.com/angr/archinfo"
 
 [project.optional-dependencies]
+capstone = [
+    "capstone>=6.0.0a1",
+]
 pcode = [
     "pypcode~=4.0",
 ]


### PR DESCRIPTION
Drop capstone <6.0 compat fallbacks and require capstone >=6.0

Per maintainer @twizmwazin's instruction on PR #353:
"If bumping capstone to 6.0, please do remove the compat code for
capstone<6. It should remain an optional dependency."

Changes:
- arch_aarch64.py: remove hasattr() fallback, use CS_ARCH_AARCH64 directly
- arch_s390x.py: remove hasattr() fallback, use CS_ARCH_SYSTEMZ directly
- arch_riscv64.py: remove hasattr(CS_ARCH_RISCV) guard (exists in all >=6.0)
- pyproject.toml: add optional capstone>=6.0.0a1 dependency

Note: uses >=6.0.0a1 because capstone has not shipped a stable 6.0.0
on PyPI yet (latest is 6.0.0a9). PEP 440 correctly orders pre-releases
before the release, so >=6.0.0 would exclude all published versions.