### PR TITLE
Support narrow p-code stack pointers

### DIFF
--- a/archinfo/arch_pcode.py
+++ b/archinfo/arch_pcode.py
@@ -122,7 +122,9 @@ class ArchPcode(Arch):
         sp_bits = self.bits
         if "sp" in archinfo_regs:
             sp_bits = archinfo_regs["sp"].size * 8
-        self.initial_sp = (0x8000 << (sp_bits - 16)) - 1
+        # start the stack at the top of the lower half of the stack pointer's range. The stack pointer can be
+        # narrower than the address space; the 8051, for instance, has a one-byte SP on a 16-bit address space.
+        self.initial_sp = (1 << (sp_bits - 1)) - 1
         self.linux_name = ""  # FIXME
         self.triplet = ""  # FIXME
 

--- a/tests/test_pcode.py
+++ b/tests/test_pcode.py
@@ -32,6 +32,17 @@ class TestArchPcode(unittest.TestCase):
         assert arch.registers["pc"] == arch.registers["rip"]
         assert arch.ip_offset == arch.registers["rip"][0]
 
+    def test_arch_with_narrow_stack_pointer(self):
+        """The 8051's stack pointer is one byte wide, narrower than its 16-bit address space."""
+        arch = ArchPcode("8051:BE:16:default")
+        assert arch.registers["sp"][1] == 1
+        assert arch.initial_sp == 0x7F
+
+        # architectures with a stack pointer at least 16 bits wide keep the initial stack pointer they always had
+        assert ArchPcode("z80:LE:16:default").initial_sp == 0x7FFF
+        assert ArchPcode("68000:BE:32:default").initial_sp == 0x7FFFFFFF
+        assert ArchPcode("x86:LE:64:default").initial_sp == 0x7FFFFFFFFFFFFFFF
+
     def test_arch_bad_langid(self):
         with self.assertRaises(ArchError):
             ArchPcode("invalid")


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

`ArchPcode` derived the initial stack pointer with an expression that assumed a stack pointer at least 16 bits wide, so constructing an architecture with a narrower one — the 8051 and the 8048 have a one-byte stack pointer on a 16-bit address space — raised `ValueError: negative shift count`.

Deriving the value from the stack pointer's own width instead fixes it where the register sizes are read, and leaves every architecture with a wider stack pointer exactly where it was.

The regression constructs `ArchPcode("8051:BE:16:default")` and pins the unchanged value for z80, 68000 and x86-64.

Validation: https://github.com/angr/archinfo/pull/363#issuecomment-5232368960. Related: angr/cle#717, angr/angr#6793.

session: mega-corpus
