### PR TITLE
Reject word sizes struct cannot express

### DIFF
--- a/archinfo/arch.py
+++ b/archinfo/arch.py
@@ -387,6 +387,10 @@ class Arch:
         """
         Produce a format string for use in python's ``struct`` module to decode a single word.
 
+        ``struct`` has integer format characters for 1, 2, 4 and 8 bytes only. Any other size, the
+        3-byte word of a 24-bit architecture included, raises ``ValueError`` and has to be assembled
+        from bytes by the caller.
+
         :param int size:    The size in bytes to pack/unpack. Defaults to wordsize
         :param bool signed: Whether the data should be extracted signed/unsigned. Default unsigned
         :param str endness: The endian to use in packing/unpacking. Defaults to memory endness
@@ -412,12 +416,10 @@ class Arch:
             fmt_size = "I"
         elif size == 2:
             fmt_size = "H"
-        elif size == 3:
-            fmt_size = "Z"  # special case for 24-bit architectures like AVR8
         elif size == 1:
             fmt_size = "B"
         else:
-            raise ValueError("Invalid size: Must be a integer power of 2 less than 16")
+            raise ValueError(f"Invalid size: struct has no format character for a {size}-byte integer")
 
         if signed:
             fmt_size = fmt_size.lower()

--- a/archinfo/arch.py
+++ b/archinfo/arch.py
@@ -840,7 +840,7 @@ def register_arch(regexes: List[str], bits: int, endness: Endness, my_arch: Type
     if not isinstance(regexes, list):
         raise TypeError("regexes must be a list")
     for rx in regexes:
-        if not isinstance(rx, str) and not isinstance(rx, re._pattern_type):
+        if not isinstance(rx, (str, re.Pattern)):
             raise TypeError("Each regex must be a string or compiled regular expression")
         try:
             re.compile(rx)

--- a/tests/test_pcode.py
+++ b/tests/test_pcode.py
@@ -47,6 +47,13 @@ class TestArchPcode(unittest.TestCase):
         with self.assertRaises(ArchError):
             ArchPcode("invalid")
 
+    def test_struct_fmt_24bit(self):
+        # struct has no format character for the 3-byte word of a 24-bit architecture
+        arch = ArchPcode("HCS-12:BE:24:default")
+        assert arch.bits == 24
+        with self.assertRaises(ValueError):
+            arch.struct_fmt()
+
     def test_pickle(self):
         arch = ArchPcode("68000:BE:32:default")
         pickle.dumps(arch)

--- a/tests/test_struct_fmt.py
+++ b/tests/test_struct_fmt.py
@@ -1,0 +1,23 @@
+# pylint:disable=missing-class-docstring,no-self-use
+import struct
+import unittest
+
+from archinfo import ArchAMD64
+
+
+class TestStructFmt(unittest.TestCase):
+    def test_sizes_struct_can_express(self):
+        arch = ArchAMD64()
+        for size in (1, 2, 4, 8):
+            for signed in (False, True):
+                assert struct.calcsize(arch.struct_fmt(size=size, signed=signed)) == size
+
+    def test_sizes_struct_cannot_express(self):
+        arch = ArchAMD64()
+        for size in (0, 3, 5, 6, 7, 16):
+            with self.assertRaises(ValueError):
+                arch.struct_fmt(size=size)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`Arch.struct_fmt()` returns the format character `Z` for a three-byte word, and `struct` has no such character, so every caller that uses the string it hands back raises. It fires on the 14 of pypcode's 187 sleigh languages whose word is 24 bits — the PIC, dsPIC, HCS-12 and extended AVR families — and on any explicit `struct_fmt(size=3)`:

```
ArchPcode('HCS-12:BE:24:default')  bits=24 bytes=3
    .struct_fmt()                          -> '>Z'
    struct.calcsize('>Z')                  -> error: bad char in struct format
    struct.unpack('>Z', b'\x01\x02\x03')   -> error: bad char in struct format
```

The exception surfaces at the caller's `struct` call, naming a format string the caller never wrote, rather than at the architecture that produced it.

### Root cause

`archinfo/arch.py` maps size 3 to a character `struct` does not define:

```python
elif size == 3:
    fmt_size = "Z"  # special case for 24-bit architectures like AVR8
```

`struct` has integer format characters for 1, 2, 4 and 8 bytes and nothing for 3, so no character can be correct here. The `else` branch of the same chain already raises for 5, 6, 7 and 16; three bytes was the one invalid size that returned a value instead of raising.

### Fix

Delete the `size == 3` branch so a three-byte word falls into the existing `else`:

```
ArchPcode('HCS-12:BE:24:default')  bits=24 bytes=3
    .struct_fmt()                          -> ValueError: Invalid size: struct has no format character for a 3-byte integer
```

The message names the size rather than claiming the argument must be a power of two, which the old text asserted and which this function never required. A caller that has to read a 24-bit word assembles it from bytes; `struct_fmt` cannot do that for them, and the call is where saying so belongs. The docstring records the constraint so the next reader does not put a character back.

### Testing

`tests/test_struct_fmt.py` asserts that `struct.calcsize(arch.struct_fmt(size=n))` equals `n` for every size `struct` can express, signed and unsigned, and that 0, 3, 5, 6, 7 and 16 raise. `tests/test_pcode.py::test_struct_fmt_24bit` pins the p-code case. Both fail on master, where the 24-bit call returns `'>Z'` and `calcsize` rejects it.

angr/cle#721 is the other half of this. Validation: https://github.com/angr/archinfo/pull/364#issuecomment-5233538253

sync: angr/cle#721

session: sharpen