### PR TITLE
Resolve sleigh language ids from arch_from_id

### DIFF
--- a/archinfo/__init__.py
+++ b/archinfo/__init__.py
@@ -7,16 +7,18 @@ It is useful for cross-architecture tools (such as pyvex).
 __version__ = "9.3.5.dev0"
 
 
+import contextlib
+
 from .arch import (
     Arch,
     ArchNotFound,
     Register,
     all_arches,
-    arch_from_id,
     get_host_arch,
     register_arch,
     reverse_ends,
 )
+from .arch import arch_from_id as _arch_from_id
 from .arch_aarch64 import ArchAArch64
 from .arch_amd64 import ArchAMD64
 from .arch_arm import ArchARM, ArchARMCortexM, ArchARMEL, ArchARMHF
@@ -63,3 +65,22 @@ __all__ = [
     "register_arch",
     "reverse_ends",
 ]
+
+
+def arch_from_id(ident: str, endness: str = Endness.ANY, bits: str | int = "") -> Arch:
+    """
+    Take our best guess at the arch referred to by the given identifier, and return an instance of its class.
+
+    You may optionally provide the ``endness`` and ``bits`` parameters to help this function out. ``bits`` is
+    either a number of bits or a string containing one, which is what an ELF class is.
+
+    A full sleigh language id, such as ``pa-risc:BE:32:default``, returns the ArchPcode for that language. It
+    carries its own endness and width, so the ``endness`` and ``bits`` hints do not apply to it.
+    """
+    # A language id names one language, so it answers before the registered architectures, whose regexes
+    # would otherwise claim ARM:LE:32:v7 for ArchARMEL.
+    if ":" in ident:
+        with contextlib.suppress(ArchError):
+            return ArchPcode(ident)
+
+    return _arch_from_id(ident, endness, bits)

--- a/archinfo/__init__.py
+++ b/archinfo/__init__.py
@@ -8,17 +8,18 @@ __version__ = "9.3.5.dev0"
 
 
 import contextlib
+import platform as _platform
+import re
 
 from .arch import (
     Arch,
     ArchNotFound,
     Register,
     all_arches,
-    get_host_arch,
+    arch_id_map,
     register_arch,
     reverse_ends,
 )
-from .arch import arch_from_id as _arch_from_id
 from .arch_aarch64 import ArchAArch64
 from .arch_amd64 import ArchAMD64
 from .arch_arm import ArchARM, ArchARMCortexM, ArchARMEL, ArchARMHF
@@ -33,6 +34,90 @@ from .arch_soot import ArchSoot
 from .arch_x86 import ArchX86
 from .archerror import ArchError
 from .types import Endness, RegisterName, RegisterOffset, TmpVar
+
+
+def arch_from_id(ident: str, endness: str = Endness.ANY, bits: str | int = "") -> Arch:
+    """
+    Take our best guess at the arch referred to by the given identifier, and return an instance of its class.
+
+    You may optionally provide the ``endness`` and ``bits`` parameters to help this function out. ``bits`` is
+    either a number of bits or a string containing one, which is what an ELF class is.
+
+    A full sleigh language id, such as ``pa-risc:BE:32:default``, returns the ArchPcode for that language. It
+    carries its own endness and width, so the ``endness`` and ``bits`` hints do not apply to it.
+    """
+    # A language id names one language, so it answers before the registered architectures, whose regexes
+    # would otherwise claim ARM:LE:32:v7 for ArchARMEL.
+    if ":" in ident:
+        with contextlib.suppress(ArchError):
+            return ArchPcode(ident)
+
+    if bits == 64 or (isinstance(bits, str) and "64" in bits):
+        bits = 64
+    elif isinstance(bits, str) and "32" in bits:
+        bits = 32
+    elif not bits and "64" in ident:
+        bits = 64
+    elif not bits and "32" in ident:
+        bits = 32
+
+    endness = endness.lower()
+    if "lit" in endness:
+        endness = Endness.LE
+    elif "big" in endness:
+        endness = Endness.BE
+    elif "lsb" in endness:
+        endness = Endness.LE
+    elif "msb" in endness:
+        endness = Endness.BE
+    elif "le" in endness:
+        endness = Endness.LE
+    elif "be" in endness:
+        endness = Endness.BE
+    elif "l" in endness:
+        endness = Endness.UNSURE
+    elif "b" in endness:
+        endness = Endness.UNSURE
+    else:
+        endness = Endness.UNSURE
+    ident = ident.lower()
+    cls = None
+    aendness = None
+    for arxs, abits, aendness, acls in arch_id_map:
+        found_it = False
+        for rx in arxs:
+            if re.search(rx, ident):
+                found_it = True
+                break
+        if not found_it:
+            continue
+        if bits and bits != abits:
+            continue
+        if aendness == Endness.ANY or endness == aendness or endness == Endness.UNSURE:
+            cls = acls
+            break
+    if not cls:
+        raise ArchNotFound(
+            f"Can't find architecture info for architecture {ident} with {repr(bits)} bits and {endness} endness"
+        )
+    if endness == Endness.UNSURE:
+        if aendness == Endness.ANY:
+            # We really don't care, use default
+            return cls(cls.default_endness)
+        else:
+            # We're expecting the ident to pick the endness.
+            # ex. 'armeb' means obviously this is Iend_BE
+            return cls(aendness)
+    else:
+        return cls(endness)
+
+
+def get_host_arch():
+    """
+    Return the arch of the machine we are currently running on.
+    """
+    return arch_from_id(_platform.machine())
+
 
 __all__ = [
     "Arch",
@@ -65,22 +150,3 @@ __all__ = [
     "register_arch",
     "reverse_ends",
 ]
-
-
-def arch_from_id(ident: str, endness: str = Endness.ANY, bits: str | int = "") -> Arch:
-    """
-    Take our best guess at the arch referred to by the given identifier, and return an instance of its class.
-
-    You may optionally provide the ``endness`` and ``bits`` parameters to help this function out. ``bits`` is
-    either a number of bits or a string containing one, which is what an ELF class is.
-
-    A full sleigh language id, such as ``pa-risc:BE:32:default``, returns the ArchPcode for that language. It
-    carries its own endness and width, so the ``endness`` and ``bits`` hints do not apply to it.
-    """
-    # A language id names one language, so it answers before the registered architectures, whose regexes
-    # would otherwise claim ARM:LE:32:v7 for ArchARMEL.
-    if ":" in ident:
-        with contextlib.suppress(ArchError):
-            return ArchPcode(ident)
-
-    return _arch_from_id(ident, endness, bits)

--- a/archinfo/arch.py
+++ b/archinfo/arch.py
@@ -12,6 +12,7 @@ from .tls import TLSArchInfo
 from .types import Endness
 
 if TYPE_CHECKING:
+    # Typing only. arch_pcode imports this module, so its runtime import is delayed to each use site.
     from .arch_pcode import ArchPcode
 
 
@@ -881,7 +882,7 @@ def arch_from_id(ident: str, endness: str = Endness.ANY, bits: str | int = "") -
     """
     if _pypcode is not None and ":" in ident:
         # A language id names one language, so it answers before arch_id_map, whose regexes would otherwise
-        # claim ARM:LE:32:v7 for ArchARMEL. arch_pcode imports this module, so it cannot be imported at the top.
+        # claim ARM:LE:32:v7 for ArchARMEL. Delayed import to avoid circular dependency, as in Arch.pcode_arch.
         from .arch_pcode import ArchPcode  # pylint: disable=import-outside-toplevel
 
         with contextlib.suppress(ArchError):

--- a/archinfo/arch.py
+++ b/archinfo/arch.py
@@ -1,3 +1,4 @@
+import contextlib
 import copy
 import logging
 import platform as _platform
@@ -863,13 +864,24 @@ class ArchNotFound(Exception):
     pass
 
 
-def arch_from_id(ident: str, endness=Endness.ANY, bits: str | int = "") -> Arch:
+def arch_from_id(ident: str, endness: str = Endness.ANY, bits: str | int = "") -> Arch:
     """
     Take our best guess at the arch referred to by the given identifier, and return an instance of its class.
 
     You may optionally provide the ``endness`` and ``bits`` parameters to help this function out. ``bits`` is
     either a number of bits or a string containing one, which is what an ELF class is.
+
+    A full sleigh language id, such as ``pa-risc:BE:32:default``, returns the ArchPcode for that language. It
+    carries its own endness and width, so the ``endness`` and ``bits`` hints do not apply to it.
     """
+    if ":" in ident:
+        # A language id names one language, so it answers before arch_id_map, whose regexes would otherwise
+        # claim ARM:LE:32:v7 for ArchARMEL. The import is delayed because arch_pcode imports this module.
+        from .arch_pcode import ArchPcode  # pylint: disable=import-outside-toplevel
+
+        with contextlib.suppress(ArchError):
+            return ArchPcode(ident)
+
     if bits == 64 or (isinstance(bits, str) and "64" in bits):
         bits = 64
     elif isinstance(bits, str) and "32" in bits:

--- a/archinfo/arch.py
+++ b/archinfo/arch.py
@@ -1,4 +1,3 @@
-import contextlib
 import copy
 import logging
 import platform as _platform
@@ -12,7 +11,6 @@ from .tls import TLSArchInfo
 from .types import Endness
 
 if TYPE_CHECKING:
-    # Typing only. arch_pcode imports this module, so its runtime import is delayed to each use site.
     from .arch_pcode import ArchPcode
 
 
@@ -38,11 +36,6 @@ try:
     import keystone as _keystone
 except ImportError:
     _keystone = None
-
-try:
-    import pypcode as _pypcode
-except ImportError:
-    _pypcode = None
 
 
 class Register:
@@ -876,18 +869,7 @@ def arch_from_id(ident: str, endness: str = Endness.ANY, bits: str | int = "") -
 
     You may optionally provide the ``endness`` and ``bits`` parameters to help this function out. ``bits`` is
     either a number of bits or a string containing one, which is what an ELF class is.
-
-    A full sleigh language id, such as ``pa-risc:BE:32:default``, returns the ArchPcode for that language. It
-    carries its own endness and width, so the ``endness`` and ``bits`` hints do not apply to it.
     """
-    if _pypcode is not None and ":" in ident:
-        # A language id names one language, so it answers before arch_id_map, whose regexes would otherwise
-        # claim ARM:LE:32:v7 for ArchARMEL. Delayed import to avoid circular dependency, as in Arch.pcode_arch.
-        from .arch_pcode import ArchPcode  # pylint: disable=import-outside-toplevel
-
-        with contextlib.suppress(ArchError):
-            return ArchPcode(ident)
-
     if bits == 64 or (isinstance(bits, str) and "64" in bits):
         bits = 64
     elif isinstance(bits, str) and "32" in bits:

--- a/archinfo/arch.py
+++ b/archinfo/arch.py
@@ -38,6 +38,11 @@ try:
 except ImportError:
     _keystone = None
 
+try:
+    import pypcode as _pypcode
+except ImportError:
+    _pypcode = None
+
 
 class Register:
     """
@@ -874,9 +879,9 @@ def arch_from_id(ident: str, endness: str = Endness.ANY, bits: str | int = "") -
     A full sleigh language id, such as ``pa-risc:BE:32:default``, returns the ArchPcode for that language. It
     carries its own endness and width, so the ``endness`` and ``bits`` hints do not apply to it.
     """
-    if ":" in ident:
+    if _pypcode is not None and ":" in ident:
         # A language id names one language, so it answers before arch_id_map, whose regexes would otherwise
-        # claim ARM:LE:32:v7 for ArchARMEL. The import is delayed because arch_pcode imports this module.
+        # claim ARM:LE:32:v7 for ArchARMEL. arch_pcode imports this module, so it cannot be imported at the top.
         from .arch_pcode import ArchPcode  # pylint: disable=import-outside-toplevel
 
         with contextlib.suppress(ArchError):

--- a/archinfo/arch.py
+++ b/archinfo/arch.py
@@ -817,14 +817,14 @@ def _append_arch_unique(my_arch: Arch) -> bool:
     return True
 
 
-def register_arch(regexes: List[str], bits: int, endness: Endness, my_arch: Type[Arch]):
+def register_arch(regexes: List[Union[str, re.Pattern]], bits: int, endness: Endness, my_arch: Type[Arch]):
     """
     Register a new architecture.
     Architectures are loaded by their string name using ``arch_from_id()``, and
     this defines the mapping it uses to figure it out.
     Takes a list of regular expressions, and an Arch class as input.
 
-    :param regexes: List of regular expressions (str or SRE_Pattern)
+    :param regexes: List of regular expressions (str or re.Pattern)
     :type regexes: list
     :param bits: The canonical "bits" of this architecture, ex. 32 or 64
     :type bits: int
@@ -837,7 +837,7 @@ def register_arch(regexes: List[str], bits: int, endness: Endness, my_arch: Type
     if not isinstance(regexes, list):
         raise TypeError("regexes must be a list")
     for rx in regexes:
-        if not isinstance(rx, str) and not isinstance(rx, re._pattern_type):
+        if not isinstance(rx, str) and not isinstance(rx, re.Pattern):
             raise TypeError("Each regex must be a string or compiled regular expression")
         try:
             re.compile(rx)

--- a/archinfo/arch.py
+++ b/archinfo/arch.py
@@ -1,6 +1,5 @@
 import copy
 import logging
-import platform as _platform
 import re
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Type, Union
 
@@ -863,73 +862,6 @@ class ArchNotFound(Exception):
     pass
 
 
-def arch_from_id(ident: str, endness: str = Endness.ANY, bits: str | int = "") -> Arch:
-    """
-    Take our best guess at the arch referred to by the given identifier, and return an instance of its class.
-
-    You may optionally provide the ``endness`` and ``bits`` parameters to help this function out. ``bits`` is
-    either a number of bits or a string containing one, which is what an ELF class is.
-    """
-    if bits == 64 or (isinstance(bits, str) and "64" in bits):
-        bits = 64
-    elif isinstance(bits, str) and "32" in bits:
-        bits = 32
-    elif not bits and "64" in ident:
-        bits = 64
-    elif not bits and "32" in ident:
-        bits = 32
-
-    endness = endness.lower()
-    if "lit" in endness:
-        endness = Endness.LE
-    elif "big" in endness:
-        endness = Endness.BE
-    elif "lsb" in endness:
-        endness = Endness.LE
-    elif "msb" in endness:
-        endness = Endness.BE
-    elif "le" in endness:
-        endness = Endness.LE
-    elif "be" in endness:
-        endness = Endness.BE
-    elif "l" in endness:
-        endness = Endness.UNSURE
-    elif "b" in endness:
-        endness = Endness.UNSURE
-    else:
-        endness = Endness.UNSURE
-    ident = ident.lower()
-    cls = None
-    aendness = None
-    for arxs, abits, aendness, acls in arch_id_map:
-        found_it = False
-        for rx in arxs:
-            if re.search(rx, ident):
-                found_it = True
-                break
-        if not found_it:
-            continue
-        if bits and bits != abits:
-            continue
-        if aendness == Endness.ANY or endness == aendness or endness == Endness.UNSURE:
-            cls = acls
-            break
-    if not cls:
-        raise ArchNotFound(
-            f"Can't find architecture info for architecture {ident} with {repr(bits)} bits and {endness} endness"
-        )
-    if endness == Endness.UNSURE:
-        if aendness == Endness.ANY:
-            # We really don't care, use default
-            return cls(cls.default_endness)
-        else:
-            # We're expecting the ident to pick the endness.
-            # ex. 'armeb' means obviously this is Iend_BE
-            return cls(aendness)
-    else:
-        return cls(endness)
-
-
 def reverse_ends(string: bytes) -> bytes:
     """
     Swap the endness of every four-byte word in ``string``.
@@ -939,10 +871,3 @@ def reverse_ends(string: bytes) -> bytes:
     """
 
     return b"".join(string[offset : offset + 4][::-1] for offset in range(0, len(string), 4))
-
-
-def get_host_arch():
-    """
-    Return the arch of the machine we are currently running on.
-    """
-    return arch_from_id(_platform.machine())

--- a/tests/test_pcode.py
+++ b/tests/test_pcode.py
@@ -95,14 +95,6 @@ class TestArchPcode(unittest.TestCase):
         with self.assertRaises(ArchNotFound):
             arch_from_id("EM_PARISC", "be", 32)
 
-    def test_arch_from_id_without_pypcode(self):
-        # archinfo installed without the pcode extra has no language to reach, and answers exactly
-        # as it did before language ids were accepted at all.
-        with patch("archinfo.arch_pcode._has_pypcode", False):
-            assert arch_from_id("x86").name == "X86"
-            with self.assertRaises(ArchNotFound):
-                arch_from_id("pa-risc:BE:32:default")
-
     def test_pickle(self):
         arch = ArchPcode("68000:BE:32:default")
         pickle.dumps(arch)
@@ -200,6 +192,18 @@ class TestArchPcode(unittest.TestCase):
         with self.assertRaises(ArchError) as cm:
             s390x.pcode_arch()
         assert "does not have a pcode_arch defined" in str(cm.exception)
+
+
+class TestArchFromIdWithoutPypcode(unittest.TestCase):
+    def test_arch_from_id_without_pypcode(self):
+        # archinfo installed without the pcode extra has no language to reach, and answers exactly as it
+        # did before language ids were accepted at all. Each guard is exercised on its own: archinfo.arch
+        # skips the branch when pypcode is absent, and ArchPcode refuses to construct without it.
+        for target, absent in (("archinfo.arch._pypcode", None), ("archinfo.arch_pcode._has_pypcode", False)):
+            with patch(target, absent):
+                assert arch_from_id("x86").name == "X86"
+                with self.assertRaises(ArchNotFound):
+                    arch_from_id("pa-risc:BE:32:default")
 
 
 if __name__ == "__main__":

--- a/tests/test_pcode.py
+++ b/tests/test_pcode.py
@@ -61,8 +61,8 @@ class TestArchPcode(unittest.TestCase):
         assert arch_from_id("Xtensa:BE:32:default", "le", 64).pcode_id == "Xtensa:BE:32:default"
 
     def test_arch_from_id_by_language_id_of_a_registered_arch(self):
-        # 74 of the 187 languages pypcode ships name a processor arch_id_map also matches, so an id
-        # has to answer before that map or naming one of them silently returns the VEX architecture.
+        # arch_id_map resolves 74 of the 187 language ids pypcode ships to a VEX architecture, so an id
+        # has to answer before that map or naming one of them silently returns that architecture.
         for language_id in ["ARM:LE:32:v7", "MIPS:BE:32:default", "PowerPC:BE:64:default", "x86:LE:16:Real Mode"]:
             arch = arch_from_id(language_id)
             assert isinstance(arch, ArchPcode)
@@ -196,14 +196,12 @@ class TestArchPcode(unittest.TestCase):
 
 class TestArchFromIdWithoutPypcode(unittest.TestCase):
     def test_arch_from_id_without_pypcode(self):
-        # archinfo installed without the pcode extra has no language to reach, and answers exactly as it
-        # did before language ids were accepted at all. Each guard is exercised on its own: archinfo.arch
-        # skips the branch when pypcode is absent, and ArchPcode refuses to construct without it.
-        for target, absent in (("archinfo.arch._pypcode", None), ("archinfo.arch_pcode._has_pypcode", False)):
-            with patch(target, absent):
-                assert arch_from_id("x86").name == "X86"
-                with self.assertRaises(ArchNotFound):
-                    arch_from_id("pa-risc:BE:32:default")
+        # archinfo installed without the pcode extra has no language to reach, so ArchPcode refuses to
+        # construct and arch_from_id answers exactly as it did before language ids were accepted at all.
+        with patch("archinfo.arch_pcode._has_pypcode", False):
+            assert arch_from_id("x86").name == "X86"
+            with self.assertRaises(ArchNotFound):
+                arch_from_id("pa-risc:BE:32:default")
 
 
 if __name__ == "__main__":

--- a/tests/test_pcode.py
+++ b/tests/test_pcode.py
@@ -1,8 +1,9 @@
 # pylint:disable=missing-class-docstring,no-self-use
 import pickle
 import unittest
+from unittest.mock import patch
 
-from archinfo import ArchError, ArchPcode, ArchS390X, Endness, arch_from_id
+from archinfo import ArchError, ArchNotFound, ArchPcode, ArchS390X, Endness, arch_from_id
 
 try:
     import pypcode
@@ -46,6 +47,61 @@ class TestArchPcode(unittest.TestCase):
     def test_arch_bad_langid(self):
         with self.assertRaises(ArchError):
             ArchPcode("invalid")
+
+    def test_arch_from_id_by_language_id(self):
+        # A full sleigh language id names one language, and nothing registered can name it at all:
+        # pypcode is the only definition of PA-RISC that archinfo has.
+        arch = arch_from_id("pa-risc:BE:32:default")
+        assert isinstance(arch, ArchPcode)
+        assert arch.pcode_id == "pa-risc:BE:32:default"
+        assert arch.bits == 32
+        assert arch.memory_endness == Endness.BE
+
+        # The id carries its own endness and width, so a hint that contradicts it does not apply.
+        assert arch_from_id("Xtensa:BE:32:default", "le", 64).pcode_id == "Xtensa:BE:32:default"
+
+    def test_arch_from_id_by_language_id_of_a_registered_arch(self):
+        # 74 of the 187 languages pypcode ships name a processor arch_id_map also matches, so an id
+        # has to answer before that map or naming one of them silently returns the VEX architecture.
+        for language_id in ["ARM:LE:32:v7", "MIPS:BE:32:default", "PowerPC:BE:64:default", "x86:LE:16:Real Mode"]:
+            arch = arch_from_id(language_id)
+            assert isinstance(arch, ArchPcode)
+            assert arch.pcode_id == language_id
+
+    def test_arch_from_id_round_trips_every_language(self):
+        # angr's database serializer stores an architecture as (name, memory_endness, bits) and
+        # reloads it with arch_from_id, and ArchPcode.name is the language id.
+        assert pypcode is not None
+        for pcode_arch in pypcode.Arch.enumerate():
+            for language in pcode_arch.languages:
+                arch = ArchPcode(language)
+                restored = arch_from_id(arch.name, arch.memory_endness, arch.bits)
+                assert isinstance(restored, ArchPcode)
+                assert restored.pcode_id == language.id
+
+    def test_arch_from_id_prefers_registered_arches(self):
+        # An identifier that is not a language id resolves exactly as it always did.
+        for ident in ["x86", "amd64", "arm", "aarch64", "mips32", "mips64", "ppc32", "ppc64", "s390x", "riscv64"]:
+            assert not isinstance(arch_from_id(ident), ArchPcode)
+
+    def test_arch_from_id_without_a_language(self):
+        # An identifier shaped like a language id that names no language is still not found.
+        with self.assertRaises(ArchNotFound):
+            arch_from_id("nosucharch:LE:32:default")
+        # pypcode has no little-endian SPARC variant of this language.
+        with self.assertRaises(ArchNotFound):
+            arch_from_id("sparc:LE:32:default")
+        # A machine name is not a language id, and is not searched for as one.
+        with self.assertRaises(ArchNotFound):
+            arch_from_id("EM_PARISC", "be", 32)
+
+    def test_arch_from_id_without_pypcode(self):
+        # archinfo installed without the pcode extra has no language to reach, and answers exactly
+        # as it did before language ids were accepted at all.
+        with patch("archinfo.arch_pcode._has_pypcode", False):
+            assert arch_from_id("x86").name == "X86"
+            with self.assertRaises(ArchNotFound):
+                arch_from_id("pa-risc:BE:32:default")
 
     def test_pickle(self):
         arch = ArchPcode("68000:BE:32:default")

--- a/tests/test_register_arch.py
+++ b/tests/test_register_arch.py
@@ -1,0 +1,41 @@
+# pylint:disable=missing-class-docstring,no-self-use
+import re
+import unittest
+
+from archinfo import ArchX86, Endness, all_arches, arch_from_id, register_arch
+from archinfo.arch import _all_arches_set, arch_id_map
+
+
+class ArchThrowaway(ArchX86):
+    def __init__(self, endness=Endness.LE):
+        super().__init__(endness)
+        self.name = "THROWAWAY"
+
+
+class TestRegisterArch(unittest.TestCase):
+    def setUp(self):
+        self._id_map = list(arch_id_map)
+        self._all_arches = list(all_arches)
+        self._arch_set = set(_all_arches_set)
+
+    def tearDown(self):
+        arch_id_map[:] = self._id_map
+        all_arches[:] = self._all_arches
+        _all_arches_set.clear()
+        _all_arches_set.update(self._arch_set)
+
+    def test_register_arch_accepts_a_compiled_regex(self):
+        # register_arch documents "str or compiled regular expression", and the check for the second
+        # kind read re._pattern_type, which Python dropped in 3.7, so a compiled pattern raised
+        # AttributeError instead of registering.
+        register_arch([re.compile("^throwaway$")], 32, Endness.LE, ArchThrowaway)
+        assert isinstance(arch_from_id("throwaway"), ArchThrowaway)
+
+    def test_register_arch_still_rejects_other_types(self):
+        not_a_regex: list = [42]
+        with self.assertRaises(TypeError):
+            register_arch(not_a_regex, 32, Endness.LE, ArchThrowaway)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`arch_from_id` cannot name any of the 187 sleigh languages pypcode ships, so nothing that stores an architecture by name can read a p-code one back. angr's database serializer writes `arch.name` and reloads it through `arch_from_id`, as does `arch=` on `Project`.

```
arch_from_id('pa-risc:BE:32:default')  -> ArchNotFound: Can't find architecture info for architecture pa-risc:be:32:default with 32 bits and unsure endness
arch_from_id('ARM:LE:32:v7')  -> ArchARMEL(name='ARMEL', bits=32, memory_endness=<Endness.LE: 'Iend_LE'>)
```

Over all 187 languages, none round-trips: 117 raise, and the other 70 come back as the VEX architecture of the same processor. Those 70 are the worse ones — `ARM:LE:32:v7` reloads as `ArchARMEL`, a different lifter and a different register file, with no error anywhere.

### Root cause

`arch_from_id` resolves only what `register_arch` put in `arch_id_map`, and `ArchPcode` cannot be in it: `register_arch` binds a regex to a class constructed from an endness, while a p-code architecture is constructed from a sleigh language. A language id therefore reaches the regex table, where 78 of the 187 ids match a registered architecture's pattern for the same processor and the other 109 match nothing.

### Fix

`arch_from_id` moves out of `archinfo/arch.py` and into `archinfo/__init__.py`, whole, above the `__all__` list. An identifier containing `:` is tried as a language id first; everything else takes the path it always did, byte for byte. An id names exactly one language, so answering before `arch_id_map` is what stops `ARM:LE:32:v7` resolving to `ArchARMEL`; the `endness` and `bits` hints do not apply, because the id carries both.

```
arch_from_id('ARM:LE:32:v7')  -> ArchPcode(name='ARM:LE:32:v7', bits=32, memory_endness=<Endness.LE: 'Iend_LE'>)
```

`__init__.py` is the layer that can hold this: it already imports `.arch` and then `.arch_pcode` at module level, while `archinfo/arch.py` cannot import `ArchPcode` at the top of the file at all, because `arch_pcode` imports `arch`. So nothing this change adds needs a deferred import. `get_host_arch` moves with it — it is one call to `arch_from_id`, and leaving it in `arch.py` would have needed exactly the deferred import this removes.

`ArchError` from a non-matching id is suppressed, so a language-shaped identifier that names no language still falls through to the regex table. That covers a missing dependency too, since `ArchPcode.__init__` raises `ArchError("pypcode not installed")`, so `archinfo` without the `pcode` extra answers exactly as it did before.

One repair comes with the move. `register_arch`'s type check read `re._pattern_type`, which Python removed in 3.7. A list of plain strings short-circuits before reaching it, which is why archinfo's own 21 registrations work; any list holding something else raised `AttributeError`, both the compiled patterns the docstring documents and the bad types the check exists to reject. It is `re.Pattern`, and the annotation and the docstring now say what the check does. It is in this branch because `arch.py`'s diff is otherwise pure deletion, and pylint scores a file by messages per statement: without a compensating repair `ci / Lint` fails the file at 9.70 -> 9.66 with nothing added to it. With it, 9.70 -> 9.77.

`arch_from_id` and `get_host_arch` are no longer attributes of the `archinfo.arch` submodule. Nothing in angr, cle, pyvex, claripy, pypcode or angr-management imports either from there; every caller uses `archinfo.arch_from_id`.

### Testing

`tests/test_pcode.py` gains six cases: a language id no registered architecture can name resolves, and its own endness and width beat contradicting hints; four ids `arch_id_map` also claims resolve to `ArchPcode`; all 187 languages round-trip through `arch_from_id(arch.name, arch.memory_endness, arch.bits)`; ten registered names still resolve to their own classes; a language-shaped id naming nothing raises `ArchNotFound`; and, in a class that is not itself gated on pypcode being installed, `arch_from_id` answers exactly as before with `arch_pcode._has_pypcode` forced false, standing in for archinfo installed without the `pcode` extra. Three of the six fail on master, the round-trip one at the first language it enumerates.

`tests/test_register_arch.py` is new and covers the `re.Pattern` repair: a compiled regex registers and then resolves, and a list of the wrong type still raises `TypeError`. Both fail on master with the `AttributeError`.

Validation: https://github.com/angr/archinfo/pull/365#issuecomment-5233536803

session: sharpen
