### PR TITLE
ArchPcode: Report no program counter for a language that declares none.

### DIFF
--- a/archinfo/arch_pcode.py
+++ b/archinfo/arch_pcode.py
@@ -1,10 +1,13 @@
 import logging
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 from .arch import Arch, Endness, Register
 from .archerror import ArchError
 from .tls import TLSArchInfo
 from .types import RegisterOffset
+
+if TYPE_CHECKING:
+    import pypcode
 
 try:
     import pypcode
@@ -64,8 +67,7 @@ class ArchPcode(Arch):
                 archinfo_regs[pc_reg.lower()].alias_names = tuple(aliases)
 
         if pc_offset is None:
-            log.warning("Unknown program counter register offset?")
-            pc_offset = 0x80000000
+            log.debug("%s declares no program counter", self.name)
 
         sp_offset = None
         ret_offset = RegisterOffset(0)
@@ -112,7 +114,7 @@ class ArchPcode(Arch):
             sp_offset = 0x80000008
 
         self.instruction_alignment = 1
-        self.ip_offset = RegisterOffset(pc_offset)
+        self.ip_offset = None if pc_offset is None else RegisterOffset(pc_offset)
         self.sp_offset = RegisterOffset(sp_offset)
         self.bp_offset = RegisterOffset(sp_offset)
         self.ret_offset = RegisterOffset(ret_offset)

--- a/tests/test_pcode.py
+++ b/tests/test_pcode.py
@@ -17,6 +17,21 @@ class TestArchPcode(unittest.TestCase):
         assert arch.instruction_endness == Endness.BE
         assert arch.bits == 32
 
+    def test_arch_without_program_counter(self):
+        """Dalvik and the DATA languages declare no program counter, so archinfo reports none."""
+        for lang_id in ("Dalvik:LE:32:DEX_Nougat", "DATA:LE:64:default"):
+            arch = ArchPcode(lang_id)
+            assert arch.ip_offset is None
+            assert "ip" not in arch.registers
+            assert "pc" not in arch.registers
+
+    def test_arch_with_program_counter(self):
+        """A language that names its program counter keeps naming it, under pc and ip both."""
+        arch = ArchPcode("x86:LE:64:default")
+        assert arch.registers["ip"] == arch.registers["rip"]
+        assert arch.registers["pc"] == arch.registers["rip"]
+        assert arch.ip_offset == arch.registers["rip"][0]
+
     def test_arch_bad_langid(self):
         with self.assertRaises(ArchError):
             ArchPcode("invalid")


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

Dalvik and the DATA sleigh languages declare no program counter and have no register that could serve as one, so `ArchPcode` pointed `ip_offset` at `0x80000000`, an offset no register occupied. `registers["ip"]` and `register_names[ip_offset]` raised `KeyError`, `get_register_by_name("ip")` returned `None`, and `translate_register_name` returned the decimal offset.

`ip_offset` is now left unset for those languages. `Arch` already declares it optional, and of the 187 languages pypcode ships only those 15 change: they lose the invented offset, and no other field of any language moves.

The regression covers both affected families, `Dalvik:LE:32:DEX_Nougat` and `DATA:LE:64:default`.

Raised in review of angr/angr#6804, which makes angr tolerate the missing register and carries the end-to-end regression.

Validation: https://github.com/angr/archinfo/pull/367#issuecomment-5259794246
