### PR TITLE
Report the nop and ret encodings a big-endian machine holds in memory

### DIFF
--- a/archinfo/arch.py
+++ b/archinfo/arch.py
@@ -2,7 +2,6 @@ import copy
 import logging
 import platform as _platform
 import re
-import struct as _struct
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Type, Union
 
 from archinfo.types import RegisterName, RegisterOffset
@@ -200,8 +199,9 @@ class Arch:
             if _keystone and self.ks_mode is not None:
                 self.ks_mode -= _keystone.KS_MODE_LITTLE_ENDIAN
                 self.ks_mode += _keystone.KS_MODE_BIG_ENDIAN
-            self.ret_instruction = reverse_ends(self.ret_instruction)
-            self.nop_instruction = reverse_ends(self.nop_instruction)
+            if self.instruction_endness == Endness.BE:
+                self.ret_instruction = reverse_ends(self.ret_instruction)
+                self.nop_instruction = reverse_ends(self.nop_instruction)
 
         if self.register_list and _pyvex is not None:
             (_, _), max_offset = max(_pyvex.vex_ffi.guest_offsets.items(), key=lambda x: x[1])
@@ -929,11 +929,15 @@ def arch_from_id(ident: str, endness=Endness.ANY, bits="") -> Arch:
         return cls(endness)
 
 
-def reverse_ends(string):
-    count = (len(string) + 3) // 4
-    ise = "I" * count
-    string += b"\x00" * (count * 4 - len(string))
-    return _struct.pack(">" + ise, *_struct.unpack("<" + ise, string))
+def reverse_ends(string: bytes) -> bytes:
+    """
+    Swap the endness of every four-byte word in ``string``.
+
+    A trailing group of fewer than four bytes is reversed on its own, so the result always has the
+    same length as the input.
+    """
+
+    return b"".join(string[offset : offset + 4][::-1] for offset in range(0, len(string), 4))
 
 
 def get_host_arch():

--- a/archinfo/arch_s390x.py
+++ b/archinfo/arch_s390x.py
@@ -65,7 +65,7 @@ class ArchS390X(Arch):
     if _keystone:
         ks_arch = _keystone.KS_ARCH_SYSTEMZ
         ks_mode = _keystone.KS_MODE_BIG_ENDIAN
-    ret_instruction = b"\x07\xf4"  # br %r14
+    ret_instruction = b"\xfe\x07"  # br %r14
     nop_instruction = b"\x07\x07"  # nopr %r7
     instruction_alignment = 2
     register_list = [

--- a/tests/test_instruction_bytes.py
+++ b/tests/test_instruction_bytes.py
@@ -1,0 +1,70 @@
+import unittest
+
+from archinfo import (
+    ArchAArch64,
+    ArchAMD64,
+    ArchARM,
+    ArchMIPS32,
+    ArchMIPS64,
+    ArchPPC32,
+    ArchPPC64,
+    ArchRISCV64,
+    ArchS390X,
+    ArchX86,
+)
+from archinfo.arch import Endness, reverse_ends
+
+# The encoding each architecture holds in memory, as a disassembler reads it.
+EXPECTED = [
+    # (class, endness, nop_instruction, ret_instruction)
+    (ArchX86, Endness.LE, b"\x90", b"\xc3"),  # nop / ret
+    (ArchAMD64, Endness.LE, b"\x90", b"\xc3"),  # nop / ret
+    (ArchARM, Endness.LE, b"\x00\x00\x00\x00", b"\x1e\xff\x2f\xe1"),  # andeq r0, r0, r0 / bx lr
+    (ArchARM, Endness.BE, b"\x00\x00\x00\x00", b"\xe1\x2f\xff\x1e"),
+    (ArchPPC32, Endness.LE, b"\x00\x00\x00\x60", b"\x20\x00\x80\x4e"),  # nop / blr
+    (ArchPPC32, Endness.BE, b"\x60\x00\x00\x00", b"\x4e\x80\x00\x20"),
+    (ArchPPC64, Endness.LE, b"\x00\x00\x00\x60", b"\x20\x00\x80\x4e"),
+    (ArchPPC64, Endness.BE, b"\x60\x00\x00\x00", b"\x4e\x80\x00\x20"),
+    # jr $ra followed by its delay slot, or $at, $at, $zero
+    (ArchMIPS32, Endness.LE, b"\x00\x00\x00\x00", b"\x08\x00\xe0\x03\x25\x08\x20\x00"),
+    (ArchMIPS32, Endness.BE, b"\x00\x00\x00\x00", b"\x03\xe0\x00\x08\x00\x20\x08\x25"),
+    (ArchMIPS64, Endness.LE, b"\x00\x00\x00\x00", b"\x08\x00\xe0\x03\x25\x08\x20\x00"),
+    (ArchMIPS64, Endness.BE, b"\x00\x00\x00\x00", b"\x03\xe0\x00\x08\x00\x20\x08\x25"),
+    # AArch64 and RISC-V keep little-endian instructions whatever the endness of data
+    (ArchAArch64, Endness.LE, b"\x1f\x20\x03\xd5", b"\xc0\x03\x5f\xd6"),  # nop / ret
+    (ArchAArch64, Endness.BE, b"\x1f\x20\x03\xd5", b"\xc0\x03\x5f\xd6"),
+    (ArchRISCV64, Endness.LE, b"\x01\x00", b"\x82\x80"),  # c.nop / c.jr ra
+    (ArchRISCV64, Endness.BE, b"\x01\x00", b"\x82\x80"),
+    (ArchS390X, Endness.BE, b"\x07\x07", b"\x07\xfe"),  # nopr %r7 / br %r14
+]
+
+
+class TestInstructionBytes(unittest.TestCase):
+    """Check that every architecture reports the encoding a disassembler reads out of memory."""
+
+    def test_nop_and_ret_encodings(self):
+        for cls, endness, nop, ret in EXPECTED:
+            with self.subTest(arch=cls.__name__, endness=endness):
+                arch = cls(endness)
+                assert arch.nop_instruction == nop
+                assert arch.ret_instruction == ret
+
+    def test_instruction_length_is_preserved(self):
+        for cls, endness, _, _ in EXPECTED:
+            with self.subTest(arch=cls.__name__, endness=endness):
+                arch = cls(endness)
+                assert len(arch.nop_instruction) == len(cls.nop_instruction)
+                assert len(arch.ret_instruction) == len(cls.ret_instruction)
+
+    def test_reverse_ends_swaps_whole_words(self):
+        self.assertEqual(reverse_ends(b""), b"")
+        self.assertEqual(reverse_ends(b"\x01\x02\x03\x04"), b"\x04\x03\x02\x01")
+        self.assertEqual(reverse_ends(b"\x01\x02\x03\x04\x05\x06\x07\x08"), b"\x04\x03\x02\x01\x08\x07\x06\x05")
+
+    def test_reverse_ends_does_not_pad_a_short_word(self):
+        self.assertEqual(reverse_ends(b"\x01\x02"), b"\x02\x01")
+        self.assertEqual(reverse_ends(b"\x01\x02\x03\x04\x05\x06"), b"\x04\x03\x02\x01\x06\x05")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Three architectures report nop and ret encodings that no disassembler accepts. Disassembling each reported string with a decoder matching that architecture's own `instruction_endness`:

```
architecture endness  instr  nop_instruction    disassembles to        ret_instruction    disassembles to
ArchS390X    Iend_BE  BE     00000707           <decodes to nothing>   0000f407           <decodes to nothing>
ArchAArch64  Iend_BE  LE     d503201f           fnmadd s21, s30, s0, s0 d65f03c0           <decodes to nothing>
ArchRISCV64  Iend_BE  LE     00000001           c.unimp; ...           00008082           c.unimp
```

The s390x pair is four bytes long for a two-byte instruction. The AArch64 and RISC-V pairs are correct little-endian encodings byte-reversed, on two architectures that keep little-endian instructions whatever the endness of data. Anything that pads, patches or scans with these writes bytes the target cannot execute.

### Root cause

`Arch.__init__` byte-swaps both literals for every big-endian architecture:

```python
self.ret_instruction = reverse_ends(self.ret_instruction)
self.nop_instruction = reverse_ends(self.nop_instruction)
```

That condition is the endness of *data*, while an instruction encoding follows `instruction_endness`, which AArch64 and RISC-V keep little-endian in both. `reverse_ends` compounds it: it worked in four-byte words and zero-extended anything shorter, so the two-byte s390x literals came back four bytes long.

### Fix

Swap only when `instruction_endness` is big-endian, and make `reverse_ends` reverse a trailing partial group on its own, so the result always has the input's length.

```
ArchS390X    Iend_BE  BE     0707               bcr 0, %r7             07fe               br %r14
ArchAArch64  Iend_BE  LE     1f2003d5           nop                    c0035fd6           ret
ArchRISCV64  Iend_BE  LE     0100               c.nop                  8280               c.jr ra
```

`archinfo/arch_s390x.py`'s literals move to the little-endian spelling every other class uses, since they are now swapped rather than passed through, and `ret_instruction` becomes `br %r14` — the ABI return — where `07f4` disassembles to `br %r4`. PowerPC, MIPS and ARM, whose instruction endness does follow data endness, are byte-identical, as is every little-endian architecture.

### Testing

`tests/test_instruction_bytes.py` pins the encoding all ten architectures report in both endnesses, asserts that neither string changes length under the swap, and covers `reverse_ends` on inputs whose length is not a multiple of four. It fails on master for the six strings above.

Fixes #370. Validation: https://github.com/angr/archinfo/pull/371#issuecomment-5290579539

session: mega-corpus
