### PR TITLE
Add ArchMIPSN32 for 64-bit MIPS with 32-bit pointers

### DIFF
--- a/archinfo/__init__.py
+++ b/archinfo/__init__.py
@@ -21,7 +21,7 @@ from .arch_aarch64 import ArchAArch64
 from .arch_amd64 import ArchAMD64
 from .arch_arm import ArchARM, ArchARMCortexM, ArchARMEL, ArchARMHF
 from .arch_mips32 import ArchMIPS32
-from .arch_mips64 import ArchMIPS64
+from .arch_mips64 import ArchMIPS64, ArchMIPSN32
 from .arch_pcode import ArchPcode
 from .arch_ppc32 import ArchPPC32
 from .arch_ppc64 import ArchPPC64
@@ -43,6 +43,7 @@ __all__ = [
     "ArchError",
     "ArchMIPS32",
     "ArchMIPS64",
+    "ArchMIPSN32",
     "ArchNotFound",
     "ArchPPC32",
     "ArchPPC64",

--- a/archinfo/arch.py
+++ b/archinfo/arch.py
@@ -863,11 +863,12 @@ class ArchNotFound(Exception):
     pass
 
 
-def arch_from_id(ident: str, endness=Endness.ANY, bits="") -> Arch:
+def arch_from_id(ident: str, endness=Endness.ANY, bits: str | int = "") -> Arch:
     """
     Take our best guess at the arch referred to by the given identifier, and return an instance of its class.
 
-    You may optionally provide the ``endness`` and ``bits`` parameters (strings) to help this function out.
+    You may optionally provide the ``endness`` and ``bits`` parameters to help this function out. ``bits`` is
+    either a number of bits or a string containing one, which is what an ELF class is.
     """
     if bits == 64 or (isinstance(bits, str) and "64" in bits):
         bits = 64

--- a/archinfo/arch_mips64.py
+++ b/archinfo/arch_mips64.py
@@ -198,24 +198,12 @@ class ArchMIPS64(Arch):
 
 class ArchMIPSN32(ArchMIPS64):
     """
-    The MIPS n32 ABI, and the older O64 ABI alongside it.
+    The MIPS n32 ABI and the older O64 ABI.
 
-    Both put a 64-bit instruction stream in an ELFCLASS32 container: the registers and the
-    instructions are those of ArchMIPS64, while pointers, GOT slots, relocation entries and
-    symbol table entries stay 32-bit. Every ELF structure an n32 object carries is an Elf32_*
-    one, so ``bits`` -- which is what decides how wide a word CLE reads and writes -- is 32,
-    and only the decoding side is inherited from the 64-bit architecture.
+    Both MIPS n32 and O64 use 64-bit instructions. The registers and the instructions are the same as in ArchMIPS64,
+    while pointers, GOT slots, relocation entries and symbol table entries are 32-bit.
 
-    Picking ArchMIPS64 for these instead would decode correctly and then corrupt the object:
-    CLE would stride the GOT by 8 rather than 4, read an 8-byte implicit addend out of a
-    4-byte REL slot, and write 8 bytes back over the neighbouring word.
-
-    ``bits`` is therefore the width of a pointer here and nothing else. It is not the width of a
-    register, and a consumer that needs one -- to slot an argument into ``a0``, say -- has to read
-    the size out of the register file (``registers[name]`` and ``Register.size``) or state it
-    itself. n32 is the architecture that separates the two, so it is the one that catches a
-    consumer conflating them, and on a little-endian target it will not: the two disagree only
-    about which half of a 64-bit register a 32-bit value occupies.
+    Every ELF structure an n32 object carries is an Elf32_*, so ArchMIPSN32.bits is 32.
     """
 
     def __init__(self, endness=Endness.BE):

--- a/archinfo/arch_mips64.py
+++ b/archinfo/arch_mips64.py
@@ -209,6 +209,13 @@ class ArchMIPSN32(ArchMIPS64):
     Picking ArchMIPS64 for these instead would decode correctly and then corrupt the object:
     CLE would stride the GOT by 8 rather than 4, read an 8-byte implicit addend out of a
     4-byte REL slot, and write 8 bytes back over the neighbouring word.
+
+    ``bits`` is therefore the width of a pointer here and nothing else. It is not the width of a
+    register, and a consumer that needs one -- to slot an argument into ``a0``, say -- has to read
+    the size out of the register file (``registers[name]`` and ``Register.size``) or state it
+    itself. n32 is the architecture that separates the two, so it is the one that catches a
+    consumer conflating them, and on a little-endian target it will not: the two disagree only
+    about which half of a 64-bit register a 32-bit value occupies.
     """
 
     def __init__(self, endness=Endness.BE):

--- a/archinfo/arch_mips64.py
+++ b/archinfo/arch_mips64.py
@@ -221,10 +221,12 @@ class ArchMIPSN32(ArchMIPS64):
     def __init__(self, endness=Endness.BE):
         super().__init__(endness)
         if endness == Endness.BE:
+            self.pcode_id = "MIPS:BE:64:64-32addr"
             self.triplet = "mips64-linux-gnuabin32"
             self.linux_name = "mipsn32"
             self.ida_name = "mips64b"
         else:
+            self.pcode_id = "MIPS:LE:64:64-32addr"
             self.triplet = "mips64el-linux-gnuabin32"
             self.linux_name = "mipsn32el"
 

--- a/archinfo/arch_mips64.py
+++ b/archinfo/arch_mips64.py
@@ -196,5 +196,41 @@ class ArchMIPS64(Arch):
     elf_tls = TLSArchInfo(1, 16, [], [0], [], 0x7000, 0x8000)
 
 
+class ArchMIPSN32(ArchMIPS64):
+    """
+    The MIPS n32 ABI, and the older O64 ABI alongside it.
+
+    Both put a 64-bit instruction stream in an ELFCLASS32 container: the registers and the
+    instructions are those of ArchMIPS64, while pointers, GOT slots, relocation entries and
+    symbol table entries stay 32-bit. Every ELF structure an n32 object carries is an Elf32_*
+    one, so ``bits`` -- which is what decides how wide a word CLE reads and writes -- is 32,
+    and only the decoding side is inherited from the 64-bit architecture.
+
+    Picking ArchMIPS64 for these instead would decode correctly and then corrupt the object:
+    CLE would stride the GOT by 8 rather than 4, read an 8-byte implicit addend out of a
+    4-byte REL slot, and write 8 bytes back over the neighbouring word.
+    """
+
+    def __init__(self, endness=Endness.BE):
+        super().__init__(endness)
+        if endness == Endness.BE:
+            self.triplet = "mips64-linux-gnuabin32"
+            self.linux_name = "mipsn32"
+            self.ida_name = "mips64b"
+        else:
+            self.triplet = "mips64el-linux-gnuabin32"
+            self.linux_name = "mipsn32el"
+
+    bits = 32
+    name = "MIPSN32"
+    qemu_name = "mipsn32el"
+    linux_name = "mipsn32el"
+    triplet = "mips64el-linux-gnuabin32"
+    # n32 keeps the 64-bit registers but narrows the C long and the pointer.
+    sizeof = {"short": 16, "int": 32, "long": 32, "long long": 64}
+    # Two 32-bit words of thread pointer head, as on any 32-bit MIPS.
+    elf_tls = TLSArchInfo(1, 8, [], [0], [], 0x7000, 0x8000)
+
+
 register_arch([r".*mipsel.*|.*mips64el|.*mipsel64"], 64, Endness.LE, ArchMIPS64)
 register_arch([r".*mips64.*|.*mips.*"], 64, Endness.ANY, ArchMIPS64)

--- a/tests/test_mips.py
+++ b/tests/test_mips.py
@@ -35,6 +35,18 @@ class TestArchMIPSN32(unittest.TestCase):
         assert ArchMIPSN32(Endness.LE).memory_endness == Endness.LE
         assert ArchMIPSN32(Endness.LE).struct_fmt() == "<I"
 
+    def test_argument_registers_stay_64_bit(self):
+        # bits == 32 is the pointer width. Anything that slots an argument into one of these
+        # registers has to take the width from the register file, not from bits: a consumer that
+        # divides bits by eight describes a0 as four bytes and, on big-endian, then writes a 32-bit
+        # argument into the sign-extension half that the callee never reads.
+        for endness in (Endness.BE, Endness.LE):
+            arch = ArchMIPSN32(endness)
+            assert arch.bytes == 4
+            for name in ["a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7", "v0", "v1"]:
+                assert arch.registers[name][1] == 8, name
+                assert arch.registers[name] == ArchMIPS64(endness).registers[name], name
+
     def test_c_types(self):
         arch = ArchMIPSN32(Endness.BE)
         assert arch.sizeof["long"] == 32

--- a/tests/test_mips.py
+++ b/tests/test_mips.py
@@ -1,0 +1,45 @@
+# pylint:disable=no-self-use
+from __future__ import annotations
+
+import unittest
+
+from archinfo import ArchMIPS64, ArchMIPSN32
+from archinfo.arch import Endness
+
+
+class TestArchMIPSN32(unittest.TestCase):
+    """
+    n32 and O64 are 64-bit MIPS instruction streams with 32-bit pointers, so ArchMIPSN32 has to
+    disagree with ArchMIPS64 about the word size and agree with it about everything else.
+    """
+
+    def test_word_size_is_32_bit(self):
+        arch = ArchMIPSN32(Endness.BE)
+        assert arch.bits == 32
+        assert arch.bytes == 4
+        # This is what decides how wide a word CLE reads out of and writes back into a
+        # relocation slot; n32 relocation entries, GOT slots and pointers are all 4 bytes.
+        assert arch.struct_fmt() == ">I"
+
+    def test_instruction_set_is_64_bit(self):
+        arch = ArchMIPSN32(Endness.BE)
+        assert arch.vex_arch == "VexArchMIPS64"
+        assert arch.name != ArchMIPS64.name
+        # The hardware registers stay 64-bit even though a pointer does not.
+        assert arch.registers["sp"][1] == 8
+        assert arch.registers["ra"][1] == 8
+        assert arch.registers["pc"][1] == 8
+
+    def test_endness(self):
+        assert ArchMIPSN32(Endness.BE).memory_endness == Endness.BE
+        assert ArchMIPSN32(Endness.LE).memory_endness == Endness.LE
+        assert ArchMIPSN32(Endness.LE).struct_fmt() == "<I"
+
+    def test_c_types(self):
+        arch = ArchMIPSN32(Endness.BE)
+        assert arch.sizeof["long"] == 32
+        assert arch.sizeof["long long"] == 64
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mips.py
+++ b/tests/test_mips.py
@@ -6,6 +6,15 @@ import unittest
 from archinfo import ArchMIPS64, ArchMIPSN32
 from archinfo.arch import Endness
 
+try:
+    import pyvex
+except ImportError:
+    pyvex = None
+
+# archinfo declares no dependencies, so a bare install has no pyvex and Arch.__init__ leaves the
+# register file empty. Anything that reads arch.registers has to say so rather than KeyError.
+requires_pyvex = unittest.skipUnless(pyvex is not None, "the register file needs pyvex")
+
 
 class TestArchMIPSN32(unittest.TestCase):
     """
@@ -21,6 +30,7 @@ class TestArchMIPSN32(unittest.TestCase):
         # relocation slot; n32 relocation entries, GOT slots and pointers are all 4 bytes.
         assert arch.struct_fmt() == ">I"
 
+    @requires_pyvex
     def test_instruction_set_is_64_bit(self):
         arch = ArchMIPSN32(Endness.BE)
         assert arch.vex_arch == "VexArchMIPS64"
@@ -35,6 +45,7 @@ class TestArchMIPSN32(unittest.TestCase):
         assert ArchMIPSN32(Endness.LE).memory_endness == Endness.LE
         assert ArchMIPSN32(Endness.LE).struct_fmt() == "<I"
 
+    @requires_pyvex
     def test_argument_registers_stay_64_bit(self):
         # bits == 32 is the pointer width. Anything that slots an argument into one of these
         # registers has to take the width from the register file, not from bits: a consumer that

--- a/tests/test_mips.py
+++ b/tests/test_mips.py
@@ -11,9 +11,15 @@ try:
 except ImportError:
     pyvex = None
 
+try:
+    import pypcode
+except ImportError:
+    pypcode = None
+
 # archinfo declares no dependencies, so a bare install has no pyvex and Arch.__init__ leaves the
 # register file empty. Anything that reads arch.registers has to say so rather than KeyError.
 requires_pyvex = unittest.skipUnless(pyvex is not None, "the register file needs pyvex")
+requires_pypcode = unittest.skipUnless(pypcode is not None, "resolving a language id needs pypcode")
 
 
 class TestArchMIPSN32(unittest.TestCase):
@@ -57,6 +63,18 @@ class TestArchMIPSN32(unittest.TestCase):
             for name in ["a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7", "v0", "v1"]:
                 assert arch.registers[name][1] == 8, name
                 assert arch.registers[name] == ArchMIPS64(endness).registers[name], name
+
+    def test_pcode_id_names_the_32_bit_address_language(self):
+        assert ArchMIPSN32(Endness.BE).pcode_id == "MIPS:BE:64:64-32addr"
+        assert ArchMIPSN32(Endness.LE).pcode_id == "MIPS:LE:64:64-32addr"
+        for endness in (Endness.BE, Endness.LE):
+            assert ArchMIPSN32(endness).pcode_id != ArchMIPS64(endness).pcode_id
+
+    @requires_pypcode
+    def test_pcode_id_resolves(self):
+        for endness in (Endness.BE, Endness.LE):
+            arch = ArchMIPSN32(endness)
+            assert arch.pcode_arch().pcode_id == arch.pcode_id
 
     def test_c_types(self):
         arch = ArchMIPSN32(Endness.BE)


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

MIPS n32 and O64 put a 64-bit MIPS instruction stream in an ELFCLASS32 container: 64-bit instructions, 32-bit pointers and Elf32_* structures throughout. No architecture in archinfo can say that, because `bits` is both the pointer width and, through `vex_arch`, the instruction set.

On the n32 object `tests/mipsn32/n32_el_dynamic` (`e_flags` `0x80000027`, `EF_MIPS_ABI2` set) the two candidates each get one half right:

```
architecture   bits bytes vex_arch         struct_fmt  0x6c4 decodes to
ArchMIPS32       32     4 VexArchMIPS32    '<I'        <decodes to nothing>
ArchMIPS64       64     8 VexArchMIPS64    '<Q'        sd $gp, 8($sp)
```

`ArchMIPS32` cannot decode the 64-bit `sd` the prologue spills `$gp` with. `ArchMIPS64` strides that object's `.got` — `sh_entsize` 4, at `0x10a30` — by eight, so its first four slots read `0x8000000000000000 0x00010a10000006c0 0x000008b0000109f0 0x00010a2400010000`, each one two real slots glued together.

### Root cause

`Arch.__init__` derives `self.bytes` from `bits`, and `ArchMIPS64` sets `bits = 64` as a class attribute, so the width used to read and write pointers is the same number that selects the VEX guest. There is no separate knob and nothing between the two classes.

### Fix

`archinfo/arch_mips64.py` gains `ArchMIPSN32`, subclassing `ArchMIPS64` and setting `bits = 32`. It inherits the VEX guest, the capstone mode and the 8-byte register file, and narrows the pointer, `sizeof["long"]` and the TLS head to the 32-bit MIPS shape:

```
ArchMIPSN32      32     4 VexArchMIPS64    '<I'        sd $gp, 8($sp)
```

`bits` is the pointer width here and nothing else: the argument registers stay eight bytes, and a consumer that needs a register width reads it from the register file.

It is deliberately not registered for name-based lookup. `ArchMIPS32` already claims every 32-bit MIPS name, and an ABI is not recoverable from a name — detection belongs to the loader, which reads `e_flags`.

### Testing

`tests/test_mips.py` asserts the 32-bit word size and `>I`/`<I` format, the 64-bit VEX guest, that `sp`, `ra`, `pc` and the eight argument registers stay 8 bytes and equal `ArchMIPS64`'s, both `pcode_id`s and the C type sizes. It fails to import on master, which has no `ArchMIPSN32`. The fixture above comes from the binaries half of this work.

These four must land together: with the loader and the architecture definition ahead of the lifter, `MIPSN32` reaches a lifter with no entry for it and recovery on these objects drops to zero blocks. Merge order: archinfo 375, then pyvex 576, then cle 795, then angr 6982.

Validation: https://github.com/angr/archinfo/pull/375#issuecomment-5440321765

session: mega-corpus
