### PR TITLE
is_arm_arch: match archinfo's ARM base class

### DIFF
--- a/archinfo/arch_arm.py
+++ b/archinfo/arch_arm.py
@@ -28,8 +28,14 @@ except ImportError:
 # TODO: which endianness should be default?
 
 
-def is_arm_arch(a):
-    return a.name.startswith("ARM")
+def is_arm_arch(a) -> bool:
+    """
+    Whether an architecture is one of archinfo's own ARM architectures, which carry the ARM/Thumb
+    interworking model: Thumb prologues, the itstate register, and the low bit of an address as the
+    mark of a Thumb instruction. A p-code ARM language carries none of them, because it selects its
+    instruction set through its SLEIGH language instead.
+    """
+    return isinstance(a, ArchARM)
 
 
 def get_real_address_if_arm(arch, addr):

--- a/tests/test_pcode.py
+++ b/tests/test_pcode.py
@@ -2,7 +2,18 @@
 import pickle
 import unittest
 
-from archinfo import ArchError, ArchPcode, ArchS390X, Endness, arch_from_id
+from archinfo import (
+    ArchARM,
+    ArchARMCortexM,
+    ArchARMEL,
+    ArchARMHF,
+    ArchError,
+    ArchPcode,
+    ArchS390X,
+    Endness,
+    arch_from_id,
+)
+from archinfo.arch_arm import is_arm_arch
 
 try:
     import pypcode
@@ -42,6 +53,15 @@ class TestArchPcode(unittest.TestCase):
         assert ArchPcode("z80:LE:16:default").initial_sp == 0x7FFF
         assert ArchPcode("68000:BE:32:default").initial_sp == 0x7FFFFFFF
         assert ArchPcode("x86:LE:64:default").initial_sp == 0x7FFFFFFFFFFFFFFF
+
+    def test_arm_language_is_not_an_archinfo_arm_arch(self):
+        # CFG recovery in angr guards its ARM/Thumb handling with is_arm_arch and then reads Thumb
+        # prologues, the itstate register and the ARM CFG option table, none of which a p-code ARM
+        # language has. See https://github.com/angr/angr/issues/4779.
+        for language in ("ARM:LE:32:v7", "ARM:BE:32:v7", "ARM:LE:32:Cortex", "ARM:LE:32:v8"):
+            assert not is_arm_arch(ArchPcode(language))
+        for arch in (ArchARM(), ArchARMEL(), ArchARMHF(), ArchARMCortexM()):
+            assert is_arm_arch(arch)
 
     def test_arch_bad_langid(self):
         with self.assertRaises(ArchError):


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

**Withdrawn and closed.** `is_arm_arch()` is meant to answer `True` for p-code ARM languages as well as VEX ones, so the predicate is not the place to repair this. The reads that actually break, the order they break in, and the repair that respects that intent are in the closing comment on this pull request.

### Problem

`is_arm_arch` accepts every ArchPcode ARM SLEIGH language alongside ARMEL, ARMHF and ARMCortexM. Callers then read state only those three carry, so angr's CFG recovery over a binary lifted through a p-code ARM language dies before an instruction is decoded. Lifting `binaries/tests/armel/fauxware` as `archinfo.ArchPcode("ARM:LE:32:v7")`:

```
  File "angr/analyses/cfg/cfg_fast.py", line 5579, in _generate_cfgnode
    switch_mode_on_nodecode = self._arch_options.switch_mode_on_nodecode
  File "angr/analyses/cfg/cfg_arch_options.py", line 76, in __getattr__
    return self.__getattribute__(option_name)
AttributeError: 'CFGArchOptions' object has no attribute 'switch_mode_on_nodecode'
```

0 functions are recovered. The crash is real and still open; only this pull request's repair for it is wrong.

### Root cause

The predicate is a prefix test on the architecture's name:

```python
def is_arm_arch(a):
    return a.name.startswith("ARM")
```

An `ArchPcode` is named after its SLEIGH language, and every ARM language is spelled `ARM:LE:32:v7`, `ARM:BE:32:v7`, `ARM:LE:32:Cortex` and so on, so all 22 of them answer `True`. ~~What the callers go on to read is the ARM/Thumb interworking model — Thumb prologues, the itstate register, the low bit of an address as the mark of a Thumb instruction, and angr's ARM entry in the CFG option table — and a p-code ARM language carries none of it, because it selects its instruction set through SLEIGH instead.~~ That was wrong. `ARM:LE:32:v7` declares the SLEIGH context variable `TMode` and decodes differently under it, so the language does carry the ARM/Thumb model; what is missing is the data on the `ArchPcode` object — `thumb_prologs` and a capstone binding — plus an entry in angr's CFG option table, and a lifter that sets `TMode`. The `itstate` read is on angr's pyvex statement walk and never fires under the p-code engine.

### Fix

~~Ask whether the architecture is one of this repository's own ARM architectures, `isinstance(a, ArchARM)`, which is where that model lives.~~ Superseded: the predicate stays a name test. archinfo gives `ArchPcode` ARM languages `thumb_prologs`, `function_prologs` and `cs_arch`/`cs_mode`, where `ArchPcode.__init__` already special-cases `PowerPC:BE`, `Xtensa:LE` and sparc; angr makes `CFGArchOptions.OPTIONS` answer for a SLEIGH id and makes the p-code lifter set `TMode` from the low bit of the address. With the arch-level data supplied by hand and the predicate untouched, the reproducer above completes with 22 functions.

### Testing

~~`pytest tests/test_pcode.py::TestArchPcode::test_arm_language_is_not_an_archinfo_arm_arch` asserts that four p-code ARM languages answer `False`~~ — that assertion is the inverse of the intended behaviour and goes with the change. The replacement regression belongs on the pull request that adds the ARM data to `ArchPcode`, and the angr pull request holding the crash regression needs rewriting against it.

The crash is reported in https://github.com/angr/angr/issues/4779 . Validation: https://github.com/angr/archinfo/pull/376#issuecomment-5448962581

session: sharpen