### PR TITLE
Populate Arch.registers for p-code architectures without pyvex

### DIFF
--- a/archinfo/arch.py
+++ b/archinfo/arch.py
@@ -203,11 +203,11 @@ class Arch:
                 self.ret_instruction = reverse_ends(self.ret_instruction)
                 self.nop_instruction = reverse_ends(self.nop_instruction)
 
-        if self.register_list and _pyvex is not None:
-            (_, _), max_offset = max(_pyvex.vex_ffi.guest_offsets.items(), key=lambda x: x[1])
-            max_offset += self.bits
+        if self.register_list and (_pyvex is not None or not self.vex_support):
             # Register collections
-            if isinstance(self.vex_arch, str):
+            if _pyvex is not None and isinstance(self.vex_arch, str):
+                (_, _), max_offset = max(_pyvex.vex_ffi.guest_offsets.items(), key=lambda x: x[1])
+                max_offset += self.bits
                 va = self.vex_arch[7:].lower()  # pylint: disable=unsubscriptable-object
                 for r in self.register_list:
                     if r.vex_offset is None:

--- a/tests/test_pcode.py
+++ b/tests/test_pcode.py
@@ -1,6 +1,7 @@
 # pylint:disable=missing-class-docstring,no-self-use
 import pickle
 import unittest
+from unittest.mock import patch
 
 from archinfo import ArchError, ArchPcode, ArchS390X, Endness, arch_from_id
 
@@ -42,6 +43,13 @@ class TestArchPcode(unittest.TestCase):
         assert ArchPcode("z80:LE:16:default").initial_sp == 0x7FFF
         assert ArchPcode("68000:BE:32:default").initial_sp == 0x7FFFFFFF
         assert ArchPcode("x86:LE:64:default").initial_sp == 0x7FFFFFFFFFFFFFFF
+
+    def test_registers_without_pyvex(self):
+        """A p-code register file comes from pypcode, so archinfo still builds it with no pyvex installed."""
+        with patch("archinfo.arch._pyvex", None):
+            arch = ArchPcode("x86:LE:64:default")
+        assert arch.registers["ip"] == arch.registers["rip"]
+        assert arch.registers["sp"] == arch.registers["rsp"]
 
     def test_arch_bad_langid(self):
         with self.assertRaises(ArchError):


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`pip install archinfo[pcode]` installs pypcode and not pyvex, because archinfo
declares no runtime dependencies. In that configuration every `ArchPcode` comes
back with an empty register file, and two of archinfo's own tests in
`tests/test_pcode.py` fail with `KeyError: 'ip'` and `KeyError: 'sp'`:

```
>>> archinfo.ArchPcode("x86:LE:64:default").registers
{}
```

`register_names` is empty too, `artificial_registers` is never set at all, and
this is all 187 languages pypcode ships.

### Root cause

`Arch.__init__` gates the whole block on `if self.register_list and _pyvex is not
None`. Only one thing inside it needs pyvex: `vex_ffi.guest_offsets`, which fills
in the offset of a register that does not have one, and only a VEX architecture
has any. An `ArchPcode` register already carries the offset pypcode gave it.

### Fix

Do the `guest_offsets` lookup when there is a VEX architecture to look it up for,
and build the collections whenever the offsets are already known. A VEX
architecture with no pyvex still gets nothing, as before, and nothing changes at
all when pyvex is installed.

### Testing

`tests/test_pcode.py::TestArchPcode::test_registers_without_pyvex` patches
`archinfo.arch._pyvex` to `None`, which is what the failed import leaves behind,
so it runs wherever the suite runs; it fails on master and passes here. The two
tests that were already failing without pyvex pass. Across all 187 p-code
languages `ArchPcode` now produces
exactly the register state it produces with pyvex installed, and no VEX
architecture changes in either configuration.

Validation: https://github.com/angr/archinfo/pull/377#issuecomment-5469107487

session: sharpen
