### PR TITLE
Give AArch64, MIPS64 and PPC64 triplets that name a real directory

### DIFF
--- a/archinfo/arch_aarch64.py
+++ b/archinfo/arch_aarch64.py
@@ -36,7 +36,7 @@ class ArchAArch64(Arch):
     qemu_name = "aarch64"
     ida_processor = "arm"
     linux_name = "aarch64"
-    triplet = "aarch64-linux-gnueabihf"
+    triplet = "aarch64-linux-gnu"
     max_inst_bytes = 4
     ret_offset = RegisterOffset(16)
     vex_conditional_helpers = True

--- a/archinfo/arch_mips64.py
+++ b/archinfo/arch_mips64.py
@@ -26,7 +26,7 @@ class ArchMIPS64(Arch):
             self.pcode_id = "MIPS:BE:64:default"
             self.function_prologs = set()
             self.function_epilogs = set()
-            self.triplet = "mips64-linux-gnu"
+            self.triplet = "mips64-linux-gnuabi64"
             self.linux_name = "mips64"
             self.ida_name = "mips64b"
         else:
@@ -39,7 +39,7 @@ class ArchMIPS64(Arch):
     qemu_name = "mips64el"
     ida_processor = "mips64"
     linux_name = "mips64el"  # ???
-    triplet = "mips64el-linux-gnu"
+    triplet = "mips64el-linux-gnuabi64"
     max_inst_bytes = 4
     ret_offset = RegisterOffset(32)
     syscall_register_offset = 16

--- a/archinfo/arch_ppc64.py
+++ b/archinfo/arch_ppc64.py
@@ -35,7 +35,7 @@ class ArchPPC64(Arch):
             self.function_epilogs = {
                 rb"[\x00-\xff]{2}\x03\xa6([\x00-\xff]{4}){0,6}\x4e\x80\x00\x20"  # mtlr reg; ... ; blr
             }
-            self.triplet = "powerpc-linux-gnu"
+            self.triplet = "powerpc64-linux-gnu"
         else:
             self.pcode_id = "PowerPC:LE:64:default"
         self.argument_register_positions = (

--- a/tests/test_triplet.py
+++ b/tests/test_triplet.py
@@ -1,0 +1,56 @@
+# pylint:disable=no-self-use
+from __future__ import annotations
+
+import unittest
+
+import archinfo
+from archinfo.arch import Endness, all_arches
+
+# Arch.triplet is substituted into the directory names library_search_path builds, and cle
+# searches those for a target's shared libraries, so it has to be the multiarch tuple for the
+# architecture reporting it. Seven pairs are left unpinned. ArchAArch64, ArchARM and
+# ArchARMHF at big-endian, ArchPPC32 at little-endian and ArchRISCV64 at big-endian each
+# report the tuple of the opposite endness, and ArchARMCortexM at either endness reports
+# arm-none-eabi, a bare-metal triplet rather than a multiarch tuple. What those should
+# report instead is a wider question than this file settles.
+EXPECTED = {
+    ("ArchAArch64", Endness.LE): "aarch64-linux-gnu",
+    ("ArchAMD64", Endness.LE): "x86_64-linux-gnu",
+    ("ArchARMEL", Endness.LE): "arm-linux-gnueabi",
+    ("ArchARMHF", Endness.LE): "arm-linux-gnueabihf",
+    ("ArchMIPS32", Endness.BE): "mips-linux-gnu",
+    ("ArchMIPS32", Endness.LE): "mipsel-linux-gnu",
+    ("ArchMIPS64", Endness.BE): "mips64-linux-gnuabi64",
+    ("ArchMIPS64", Endness.LE): "mips64el-linux-gnuabi64",
+    ("ArchMIPSN32", Endness.BE): "mips64-linux-gnuabin32",
+    ("ArchMIPSN32", Endness.LE): "mips64el-linux-gnuabin32",
+    ("ArchPPC32", Endness.BE): "powerpc-linux-gnu",
+    ("ArchPPC64", Endness.BE): "powerpc64-linux-gnu",
+    ("ArchPPC64", Endness.LE): "powerpc64le-linux-gnu",
+    ("ArchRISCV64", Endness.LE): "riscv64-linux-gnu",
+    ("ArchS390X", Endness.BE): "s390x-linux-gnu",
+    ("ArchX86", Endness.LE): "i386-linux-gnu",
+}
+
+
+class TestTriplet(unittest.TestCase):
+    """
+    The triplet is a multiarch directory name, so it has to name the bit width, the byte order
+    and the ABI of the architecture reporting it.
+    """
+
+    def test_triplets(self):
+        for (name, endness), expected in EXPECTED.items():
+            arch = getattr(archinfo, name)(endness)
+            assert arch.triplet == expected, name
+
+    def test_gnueabihf_belongs_to_32_bit_arm(self):
+        # aarch64 carried arm's hard-float EABI suffix, which is where this test comes from.
+        for arch in all_arches:
+            if arch.triplet and "eabi" in arch.triplet:
+                assert arch.bits == 32, arch.name
+
+    def test_the_triplet_names_the_directory_cle_searches(self):
+        for (name, endness), expected in EXPECTED.items():
+            arch = getattr(archinfo, name)(endness)
+            assert f"/lib/{expected}/" in arch.library_search_path(), name


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`Arch.triplet` has one consumer. `Arch.library_search_path` substitutes it into four of the
eight directory names it builds for a 64-bit architecture -- `/lib/${TRIPLET}/`,
`/usr/lib/${TRIPLET}/`, `/usr/${TRIPLET}/lib/` and `/usr/${TRIPLET}/lib64/` -- and cle
searches those for a target's shared libraries. Five arch/endness pairs report a string
that is not the multiarch tuple of the architecture reporting it:

```
ArchAArch64  BE and LE  aarch64-linux-gnueabihf
ArchMIPS64   BE         mips64-linux-gnu
ArchMIPS64   LE         mips64el-linux-gnu
ArchPPC64    BE         powerpc-linux-gnu
```

Nothing emits `aarch64-linux-gnueabihf` for aarch64, so an AArch64 target searches
`/lib/aarch64-linux-gnueabihf/` and never looks in `/lib/aarch64-linux-gnu/`.
`powerpc-linux-gnu` is the tuple for 32-bit powerpc, so a 64-bit PowerPC target is pointed
at the 32-bit directory.

### Root cause

`gnueabihf` is 32-bit ARM's hard-float EABI suffix. `ArchAArch64` got it in f0abea2
("Support AArch64", June 2015), which added `arch_aarch64.py` whole at a revision where
`ArchARM` carried `arm-linux-gnueabihf`; only a `black` pass has touched the line since.
`ArchPPC64` at big-endian holds the 32-bit PowerPC tuple. `ArchMIPS64` drops the ABI
suffix that separates the n64 multiarch directory from n32 -- `ArchMIPSN32` already spells
its own `mips64-linux-gnuabin32` correctly.

### Fix

Four lines, moving five arch/endness pairs (`ArchAArch64`'s triplet is a class attribute,
so both endnesses follow one line) to the tuples dpkg derives for Debian `arm64`,
`mips64`, `mips64el` and `ppc64`: `aarch64-linux-gnu`, `mips64-linux-gnuabi64`,
`mips64el-linux-gnuabi64` and `powerpc64-linux-gnu`. Three of those name cross compilers
the build scripts in angr/binaries already call -- `tests_util/build_all.sh` runs
`powerpc64-linux-gnu-gcc`, `tests_src/test_ioctl/Makefile` runs
`mips64-linux-gnuabi64-gcc`, and `tests_src/test_return_type.c` records
`aarch64-linux-gnu-gcc`. 80 of the 672 paths `library_search_path(pedantic=True)` builds
across the whole arch table change; nothing else moves, and `triplet` has no reader
outside archinfo in any of the angr repositories.

Left alone on purpose: `ArchAArch64`, `ArchARM` and `ArchARMHF` at big-endian, `ArchPPC32`
at little-endian and `ArchRISCV64` at big-endian each report the tuple of the opposite
endness, and `ArchARMCortexM` reports `arm-none-eabi`, which is bare-metal rather than a
multiarch tuple. Deciding what any of those should report instead is wider than this
change, and setting `triplet = None` needs a guard in `library_search_path`, which would
otherwise raise `TypeError` on the substitution -- a base-class change, and a separate
diff.

### Testing

New `tests/test_triplet.py` pins the tuple for 16 arch/endness pairs and names the seven it
leaves unpinned. It also asserts that no 64-bit architecture carries an `eabi` suffix, and
that each pinned tuple appears in `library_search_path()`. All three tests fail on master
and pass here.

Validation: https://github.com/angr/archinfo/pull/379#issuecomment-5494337418

session: sharpen