### PR TITLE
Treat an unqualified PowerPC identifier as big-endian

### DIFF
--- a/archinfo/arch_ppc32.py
+++ b/archinfo/arch_ppc32.py
@@ -24,7 +24,7 @@ except ImportError:
 
 
 class ArchPPC32(Arch):
-    def __init__(self, endness=Endness.LE):
+    def __init__(self, endness=Endness.BE):
         super().__init__(endness)
         if endness == Endness.BE:
             self.pcode_id = "PowerPC:BE:32:default"
@@ -57,6 +57,7 @@ class ArchPPC32(Arch):
     bits = 32
     vex_arch = "VexArchPPC32"
     name = "PPC32"
+    default_endness = Endness.BE
     qemu_name = "ppc"
     ida_processor = "ppc"
     linux_name = "ppc750"  # ?
@@ -324,4 +325,5 @@ class ArchPPC32(Arch):
 
 
 register_arch([r".*p\w*pc.*be"], 32, Endness.BE, ArchPPC32)
+register_arch([r".*p\w*pc\d*[-_]?(?:el|le)($|[^a-z])"], 32, Endness.LE, ArchPPC32)
 register_arch([r".*p\w*pc.*"], 32, Endness.ANY, ArchPPC32)

--- a/archinfo/arch_ppc64.py
+++ b/archinfo/arch_ppc64.py
@@ -23,7 +23,7 @@ except ImportError:
 
 
 class ArchPPC64(Arch):
-    def __init__(self, endness=Endness.LE):
+    def __init__(self, endness=Endness.BE):
         super().__init__(endness)
         if endness == Endness.BE:
             self.pcode_id = "PowerPC:BE:64:default"
@@ -83,6 +83,7 @@ class ArchPPC64(Arch):
     bits = 64
     vex_arch = "VexArchPPC64"
     name = "PPC64"
+    default_endness = Endness.BE
     qemu_name = "ppc64"
     ida_processor = "ppc64"
     triplet = "powerpc64le-linux-gnu"
@@ -400,4 +401,5 @@ class ArchPPC64(Arch):
 
 
 register_arch([r".*p\w*pc.*be"], 64, Endness.BE, ArchPPC64)
+register_arch([r".*p\w*pc\d*[-_]?(?:el|le)($|[^a-z])"], 64, Endness.LE, ArchPPC64)
 register_arch([r".*p\w*pc.*"], 64, Endness.ANY, ArchPPC64)

--- a/tests/test_ppc.py
+++ b/tests/test_ppc.py
@@ -1,0 +1,92 @@
+# pylint:disable=no-self-use
+from __future__ import annotations
+
+import inspect
+import unittest
+
+from archinfo import ArchPPC32, ArchPPC64, arch_from_id
+from archinfo.arch import Endness
+
+# The unqualified names are the big-endian ports. The little-endian spellings carry an el or le
+# suffix -- ppc64el is the Debian architecture, powerpc64le the GNU triplet, ppc_le the name cle's
+# binja backend uses -- so a suffix is what arch_from_id has to go on.
+BIG_ENDIAN = [
+    ("ppc", ArchPPC32),
+    ("PowerPC", ArchPPC32),
+    ("powerpc", ArchPPC32),
+    ("ppc32", ArchPPC32),
+    ("ppcbe", ArchPPC32),
+    ("powerpcbe", ArchPPC32),
+    ("powerpc-linux-gnu", ArchPPC32),
+    ("powerpc-eabi", ArchPPC32),
+    ("powerpcspe", ArchPPC32),
+    # elf ends in el, which is why the little-endian pattern is not the mirror of the big-endian
+    # one. These are bare-metal big-endian targets and the suffix match must not reach them.
+    ("powerpc-elf", ArchPPC32),
+    ("ppc-elf", ArchPPC32),
+    ("powerpc-none-elf", ArchPPC32),
+    ("powerpc-elfv2", ArchPPC32),
+    ("ppc64-elf", ArchPPC64),
+    ("ppc64", ArchPPC64),
+    ("powerpc64", ArchPPC64),
+    ("ppc64be", ArchPPC64),
+    ("powerpc64-linux-gnu", ArchPPC64),
+]
+
+LITTLE_ENDIAN = [
+    ("ppcle", ArchPPC32),
+    ("ppcel", ArchPPC32),
+    ("powerpcle", ArchPPC32),
+    ("ppc64le", ArchPPC64),
+    ("ppc64el", ArchPPC64),
+    ("powerpc64le", ArchPPC64),
+    ("ppc64le-linux-gnu", ArchPPC64),
+    ("ppc64el-linux-gnu", ArchPPC64),
+    ("powerpc64le-linux-gnu", ArchPPC64),
+    # A separator may sit between the name and the suffix. ppc_le is the identifier cle's binja
+    # backend maps to a little-endian ArchPPC32.
+    ("ppc_le", ArchPPC32),
+    ("ppc-le", ArchPPC32),
+    ("powerpc-le", ArchPPC32),
+    ("ppc64_le", ArchPPC64),
+    ("ppc64_el", ArchPPC64),
+]
+
+
+class TestPPCEndnessIdentifiers(unittest.TestCase):
+    """
+    PowerPC is bi-endian and archinfo ships both, so which one an identifier means has to come
+    from the identifier. When the caller passes no endness, arch_from_id takes it from the
+    registration that matched, falling back to default_endness for a registration made with
+    Endness.ANY.
+    """
+
+    def test_unqualified_identifiers_are_big_endian(self):
+        for ident, cls in BIG_ENDIAN:
+            arch = arch_from_id(ident)
+            assert type(arch) is cls, ident
+            assert arch.memory_endness == Endness.BE, ident
+
+    def test_el_and_le_identifiers_are_little_endian(self):
+        for ident, cls in LITTLE_ENDIAN:
+            arch = arch_from_id(ident)
+            assert type(arch) is cls, ident
+            assert arch.memory_endness == Endness.LE, ident
+
+    def test_an_explicit_endness_still_wins(self):
+        for ident, _ in BIG_ENDIAN + LITTLE_ENDIAN:
+            assert arch_from_id(ident, Endness.LE).memory_endness == Endness.LE, ident
+            assert arch_from_id(ident, Endness.BE).memory_endness == Endness.BE, ident
+
+    def test_constructing_without_an_endness_agrees_with_default_endness(self):
+        # arch_from_id reads default_endness while a direct construction reads the parameter
+        # default, so the two have to name the same endness or the same architecture arrives
+        # little-endian down one path and big-endian down the other.
+        for cls in (ArchPPC32, ArchPPC64):
+            parameter = inspect.signature(cls.__init__).parameters["endness"]
+            assert parameter.default == cls.default_endness, cls.__name__
+            assert cls().memory_endness == Endness.BE, cls.__name__
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`arch_from_id` returns little-endian for `ppc`, `powerpc`, `ppc64` and `powerpc64`, and
for `powerpc-linux-gnu` and `powerpc-elf`. Those spellings name the big-endian ports;
little-endian PowerPC carries an `el` or `le` suffix, as in the Debian architecture
`ppc64el` and the GNU triplet `powerpc64le`. So `ppc64` and `ppc64le` resolve to the same
architecture today. `angr/binaries` spells it the other way round: at 981989f, the 20
PowerPC ELF files under `tests/ppc` and the 17 under `tests/ppc64` are big-endian, and the
4 little-endian ones are in `tests/ppc64el`. So does cle, whose binja backend maps `ppc`
to `ArchPPC32(endness="Iend_BE")` and `ppc_le` to the little-endian one.

### Root cause

`ArchPPC32` and `ArchPPC64` never set `default_endness`, so they inherit `Endness.LE` from
`Arch`. That attribute arrived in 1ac4ea8 ("Add enough types to pass mypy", #177), which
added `Endness.BE` to `arch_mips32.py`, `arch_mips64.py` and `arch_s390x.py` and edited
both PowerPC files in the same commit without adding it there.

PowerPC also has no little-endian registration -- there is an entry for `.*p\w*pc.*be` and
then the catch-all, with nothing in between -- so `ppc64le` comes back little-endian only
because the class default is. Moving the default without adding that entry would turn
`ppc64le` big-endian.

### Fix

Set `default_endness = Endness.BE` on both classes, set the same value on each
`__init__`'s `endness` parameter -- that is the one a direct `ArchPPC64()` reads -- and
register the `el` and `le` suffixes, with an optional `-` or `_` before them, as
little-endian ahead of the catch-all. That pattern is deliberately not the mirror of the
big-endian one, because `elf` ends in `el`: `.*p\w*pc.*el` matches `powerpc-elf` and
`ppc-elf`, which are big-endian bare-metal targets. Requiring the suffix to end the token
is what lets `ppc_le` in without letting `elf` in.

A sweep of 55,233 `arch_from_id` calls over generated identifiers -- an alphabet that also
produces ARM, MIPS and x86 answers -- moves only PPC32 and PPC64 results, and only from
little-endian to big-endian. No answer changes class, no call that states an endness is
touched, and `all_arches` is the same.

One consequence lands in cle, not here. `cle/backends/pe/pe.py` calls `arch_from_id` with
no endness at lines 127 and 229 (cle master 2f7657fd), so a PE whose machine type is
`IMAGE_FILE_MACHINE_POWERPC` resolves big-endian after this change, and Windows NT on
PowerPC was little-endian. That repair is an explicit endness at those two call sites and
belongs in cle, as a separate change. Nothing in `angr/binaries` reaches that path: of the
95 PE files there at 981989f, none carries a PowerPC machine type.

If PowerPC is meant to default to little-endian here, say so and I will cut this back to
the little-endian registration on its own.

### Merge order

Please land #379 first. It changes `ArchPPC64`'s big-endian `triplet` from
`powerpc-linux-gnu`, the 32-bit tuple, to `powerpc64-linux-gnu`. This change makes
big-endian the default for `ArchPPC64`, so on its own it makes the 32-bit tuple the
default answer. The two touch `arch_ppc64.py` in non-overlapping hunks and merge cleanly.

### Testing

New `tests/test_ppc.py`, four tests. Two fail on master:
`test_unqualified_identifiers_are_big_endian` and
`test_constructing_without_an_endness_agrees_with_default_endness`. The other two pass on
master and here, and are there to pin what must not move:
`test_el_and_le_identifiers_are_little_endian`, which fails if the default moves without
the new registration, and `test_an_explicit_endness_still_wins`. `powerpc-elf` and
`ppc-elf` are in the big-endian list as controls for the `el` trap.

Validation: https://github.com/angr/archinfo/pull/380#issuecomment-5496591558

session: sharpen