### PR TITLE
Give little-endian PPC32 the triplet of its own byte order

### DIFF
--- a/archinfo/arch_ppc32.py
+++ b/archinfo/arch_ppc32.py
@@ -38,6 +38,7 @@ class ArchPPC32(Arch):
             }
         else:
             self.pcode_id = "PowerPC:LE:32:default"
+            self.triplet = "powerpcle-linux-gnu"
 
         self.argument_register_positions = (
             {

--- a/tests/test_ppc.py
+++ b/tests/test_ppc.py
@@ -87,6 +87,17 @@ class TestPPCEndnessIdentifiers(unittest.TestCase):
             assert parameter.default == cls.default_endness, cls.__name__
             assert cls().memory_endness == Endness.BE, cls.__name__
 
+    def test_the_triplet_names_the_same_architecture_it_came_from(self):
+        # The triplet is an identifier for the architecture reporting it, so feeding it back
+        # to arch_from_id has to return the same class and the same endness.
+        for cls in (ArchPPC32, ArchPPC64):
+            for endness in (Endness.BE, Endness.LE):
+                arch = cls(endness)
+                assert arch.triplet is not None, cls.__name__
+                back = arch_from_id(arch.triplet)
+                assert type(back) is cls, arch.triplet
+                assert back.memory_endness == endness, arch.triplet
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_triplet.py
+++ b/tests/test_triplet.py
@@ -8,11 +8,10 @@ from archinfo.arch import Endness, all_arches
 
 # Arch.triplet is substituted into the directory names library_search_path builds, and cle
 # searches those for a target's shared libraries, so it has to be the multiarch tuple for the
-# architecture reporting it. Seven pairs are left unpinned. ArchAArch64, ArchARM and
-# ArchARMHF at big-endian, ArchPPC32 at little-endian and ArchRISCV64 at big-endian each
-# report the tuple of the opposite endness, and ArchARMCortexM at either endness reports
-# arm-none-eabi, a bare-metal triplet rather than a multiarch tuple. What those should
-# report instead is a wider question than this file settles.
+# architecture reporting it. Six pairs are left unpinned. ArchAArch64, ArchARM, ArchARMHF and
+# ArchRISCV64 at big-endian each report the tuple of the opposite endness, and ArchARMCortexM
+# at either endness reports arm-none-eabi, a bare-metal triplet rather than a multiarch tuple.
+# What those should report instead is a wider question than this file settles.
 EXPECTED = {
     ("ArchAArch64", Endness.LE): "aarch64-linux-gnu",
     ("ArchAMD64", Endness.LE): "x86_64-linux-gnu",
@@ -25,6 +24,7 @@ EXPECTED = {
     ("ArchMIPSN32", Endness.BE): "mips64-linux-gnuabin32",
     ("ArchMIPSN32", Endness.LE): "mips64el-linux-gnuabin32",
     ("ArchPPC32", Endness.BE): "powerpc-linux-gnu",
+    ("ArchPPC32", Endness.LE): "powerpcle-linux-gnu",
     ("ArchPPC64", Endness.BE): "powerpc64-linux-gnu",
     ("ArchPPC64", Endness.LE): "powerpc64le-linux-gnu",
     ("ArchRISCV64", Endness.LE): "riscv64-linux-gnu",


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`ArchPPC32` reports the same triplet at both byte orders, while `ArchPPC64` reports one for each:

```
ArchPPC32  Iend_BE  bits=32  triplet='powerpc-linux-gnu'
ArchPPC32  Iend_LE  bits=32  triplet='powerpc-linux-gnu'
ArchPPC64  Iend_BE  bits=64  triplet='powerpc64-linux-gnu'
ArchPPC64  Iend_LE  bits=64  triplet='powerpc64le-linux-gnu'
```

`powerpc-linux-gnu` is the multiarch tuple of the big-endian port. `Arch.triplet` has one consumer, `Arch.library_search_path`, which substitutes it into the directory names it returns; cle searches those for a target's shared libraries. A little-endian PPC32 target is therefore sent to `/lib/powerpc-linux-gnu/`, which is where a Debian system keeps its big-endian PowerPC libraries.

Feeding each PowerPC architecture's own triplet back to `arch_from_id` shows the same thing from the other side. Three of the four pairs come back as the class and endness that produced them; the little-endian `ArchPPC32` comes back big-endian:

```
ArchPPC32 Iend_BE  powerpc-linux-gnu      -> ArchPPC32/32/Iend_BE
ArchPPC32 Iend_LE  powerpc-linux-gnu      -> ArchPPC32/32/Iend_BE
ArchPPC64 Iend_BE  powerpc64-linux-gnu    -> ArchPPC64/64/Iend_BE
ArchPPC64 Iend_LE  powerpc64le-linux-gnu  -> ArchPPC64/64/Iend_LE
```

### Root cause

`arch_ppc32.py` carries `triplet` only as a class attribute, so one string serves both instances. `arch_ppc64.py` carries the little-endian tuple as its class attribute and sets the big-endian one in `__init__`, which is what makes its two instances disagree. `ArchPPC32.__init__` already branches on endness for `pcode_id` and never gained the same line for `triplet`.

### Fix

One line in the little-endian branch of `ArchPPC32.__init__`, the shape `arch_ppc64.py` already uses.

`powerpcle-linux-gnu` is Debian's value, not one this change invents: `dpkg-architecture -apowerpcel -qDEB_HOST_MULTIARCH` answers it under dpkg 1.23.7, and the same query reproduces every string already in `tests/test_triplet.py`, `powerpc-linux-gnu` and `powerpc64le-linux-gnu` included. archinfo already resolves `powerpcle-linux-gnu`, and `powerpcel`, to a little-endian `ArchPPC32`.

Deliberately not done: the six other pairs `tests/test_triplet.py` records as unpinned, where the correct string is a wider question. This change moves one pair and the file's comment count from seven to six.

### Testing

`tests/test_triplet.py` gains the `("ArchPPC32", Endness.LE)` entry, which pins both the attribute and the `/lib/powerpcle-linux-gnu/` directory `library_search_path` builds from it. `tests/test_ppc.py` gains `test_the_triplet_names_the_same_architecture_it_came_from`, which requires each PowerPC architecture's own triplet to resolve back to that class and that endness.

Validation: https://github.com/angr/archinfo/pull/381#issuecomment-5555055936

session: sharpen
