### PR TITLE
Register ArchMIPSN32 so its name resolves to it

### DIFF
--- a/archinfo/arch_mips32.py
+++ b/archinfo/arch_mips32.py
@@ -284,4 +284,6 @@ class ArchMIPS32(Arch):
 
 
 register_arch([r"mipsel|mipsle"], 32, Endness.LE, ArchMIPS32)
-register_arch([r".*mips.*"], 32, "any", ArchMIPS32)
+# The n32 ABI is a 32-bit identifier too, but it is ArchMIPSN32, which arch_mips64.py registers.
+# Leave those identifiers to it rather than swallowing them here.
+register_arch([r"(?!.*n32).*mips.*"], 32, "any", ArchMIPS32)

--- a/archinfo/arch_mips64.py
+++ b/archinfo/arch_mips64.py
@@ -231,3 +231,8 @@ class ArchMIPSN32(ArchMIPS64):
 
 register_arch([r".*mipsel.*|.*mips64el|.*mipsel64"], 64, Endness.LE, ArchMIPS64)
 register_arch([r".*mips64.*|.*mips.*"], 64, Endness.ANY, ArchMIPS64)
+# n32 keeps the 64-bit registers and narrows the pointer, so it registers as a 32-bit
+# architecture. The rules above are 64-bit and never claim an n32 identifier, and ArchMIPS32's
+# 32-bit catch-all declines them, so these come last and still get the match.
+register_arch([r".*mips[-_]?n32(el|le).*"], 32, Endness.LE, ArchMIPSN32)
+register_arch([r".*mips[-_]?n32.*"], 32, Endness.ANY, ArchMIPSN32)

--- a/tests/test_mips.py
+++ b/tests/test_mips.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 
 import unittest
 
-from archinfo import ArchMIPS64, ArchMIPSN32
-from archinfo.arch import Endness
+import archinfo
+from archinfo import ArchMIPS32, ArchMIPS64, ArchMIPSN32, all_arches, arch_from_id
+from archinfo.arch import Arch, Endness
 
 try:
     import pyvex
@@ -80,6 +81,54 @@ class TestArchMIPSN32(unittest.TestCase):
         arch = ArchMIPSN32(Endness.BE)
         assert arch.sizeof["long"] == 32
         assert arch.sizeof["long long"] == 64
+
+
+class TestArchLookupByName(unittest.TestCase):
+    """
+    arch_from_id has to hand back the architecture whose name it was given.
+    """
+
+    def test_mipsn32_is_registered(self):
+        assert ArchMIPSN32 in {type(arch) for arch in all_arches}
+
+    def test_mipsn32_resolves_from_its_own_name(self):
+        # A caller that round-trips an architecture through its name -- angr's SimLibrary does
+        # exactly this to canonicalise the keys of its default calling-convention table -- used to
+        # get ArchMIPS32 back, which has neither the same register file nor the same instruction
+        # width. The n32 conventions then landed on the MIPS32 key and overwrote it.
+        assert type(arch_from_id(ArchMIPSN32.name)) is ArchMIPSN32
+        assert arch_from_id(ArchMIPSN32.name).name == ArchMIPSN32.name
+
+    def test_every_named_arch_resolves_from_its_own_name(self):
+        # The control for the case above: every other architecture archinfo exports already
+        # round-trips, so a failure here is about the one that does not rather than about
+        # arch_from_id being unable to resolve anything.
+        for attr in archinfo.__all__:
+            cls = getattr(archinfo, attr)
+            if not isinstance(cls, type) or not issubclass(cls, Arch):
+                continue
+            name = getattr(cls, "name", None)
+            if name is None:  # Arch and ArchPcode carry no fixed name
+                continue
+            assert arch_from_id(name).name == name, attr
+
+    def test_o32_identifiers_are_untouched(self):
+        # ArchMIPS32's catch-all now declines the n32 spellings. It still has to claim every
+        # other MIPS identifier it claimed before, in the endness it claimed it in.
+        for ident in ("mips", "mips32", "MIPS32"):
+            assert type(arch_from_id(ident)) is ArchMIPS32, ident
+        for ident in ("mipsel", "mipsle"):
+            assert type(arch_from_id(ident)) is ArchMIPS32, ident
+            assert arch_from_id(ident).memory_endness == Endness.LE, ident
+        for ident in ("mips64", "MIPS64"):
+            assert type(arch_from_id(ident)) is ArchMIPS64, ident
+        assert arch_from_id("mips64el").memory_endness == Endness.LE
+
+    def test_n32_identifiers_carry_their_endness(self):
+        assert arch_from_id("mipsn32").memory_endness == Endness.BE
+        for ident in ("mipsn32el", "mipsn32le"):
+            assert type(arch_from_id(ident)) is ArchMIPSN32, ident
+            assert arch_from_id(ident).memory_endness == Endness.LE, ident
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`arch_from_id` answers the identifier `MIPSN32` with `ArchMIPS32`:

```pycon
>>> import archinfo
>>> archinfo.arch_from_id("MIPSN32").name
'MIPS32'
>>> archinfo.ArchMIPSN32.name
'MIPSN32'
```

The two are not interchangeable. n32 is a 64-bit instruction stream with 32-bit
pointers; MIPS32 has neither the same register file (`a4`-`a7` exist only on the
64-bit one) nor the same instruction width. Anything that canonicalises an
architecture by round-tripping its name therefore gets a different architecture
back, and gets it silently.

angr does exactly that. `SimLibrary.set_default_cc` canonicalises its key with
`archinfo.arch_from_id(arch_name).name`, and `procedures/definitions/linux_kernel.py`
walks `SYSCALL_CC` calling it once per architecture. `MIPS32` is written first and
`MIPSN32` then lands on the same key and overwrites it:

```pycon
>>> from angr.procedures.definitions.linux_kernel import lib
>>> {k: v.__name__ for k, v in lib.default_ccs.items() if "MIPS" in k}
{'MIPS32': 'SimCCN32LinuxSyscall', 'MIPS64': 'SimCCN64LinuxSyscall'}
```

Every syscall SimProcedure on a MIPS32 Linux project is then given the n32
convention, whose argument registers are `a0`-`a7`. On
`binaries/tests/mips/busybox` (MIPS32 big-endian, 3518 functions),
`CompleteCallingConventions` reaches the `mmap`/`futex` stubs and dies:

```text
  File "angr/analyses/calling_convention/fact_collector.py", line 449, in _handle_function
    base_offset = self.project.arch.registers[loc.reg_name][0]
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
KeyError: 'a4'
```

Nothing catches it, so the analysis is lost for the whole binary rather than for
the one function: after the raise 139 of 3518 functions carry a calling
convention.

### Root cause

`register_arch` was never called for `ArchMIPSN32` -- it is the only class in
`archinfo.__all__` with a `name` and no `arch_id_map` entry. No rule claims its
identifiers, so `arch_from_id` falls through to ArchMIPS32's catch-all:

```python
register_arch([r".*mips.*"], 32, "any", ArchMIPS32)
```

It is the only 32-bit MIPS rule there is, and `arch_from_id` reads `bits=32`
off the `32` in `mipsn32`, so the two MIPS64 rules are never in the running.
Nothing is wrong with `SimCCO32` itself: an o32 function's fifth integer
argument is a stack slot, exactly as the ABI says, so no o32 convention can
produce an `a4`. It comes only from the wrong convention being attached.

An identifier answered with a *different* architecture is worse than
`ArchNotFound`, because the caller cannot see it happen.

### Fix

`ArchMIPS32`'s catch-all declines the n32 spellings, and `arch_mips64.py`
registers `ArchMIPSN32` for them:

```python
register_arch([r"(?!.*n32).*mips.*"], 32, "any", ArchMIPS32)
...
register_arch([r".*mips[-_]?n32(el|le).*"], 32, Endness.LE, ArchMIPSN32)
register_arch([r".*mips[-_]?n32.*"], 32, Endness.ANY, ArchMIPSN32)
```

The n32 rules sit after the 64-bit ones so that `all_arches`, which
`register_arch` appends to as well, keeps `MIPS64` ahead of `MIPSN32`.
`arch_from_id` is insensitive to that placement. `.*mips64.*|.*mips.*` does
match the string `mipsn32`; it is the bits filter, not the pattern, that
declines it. One edge changes with it: `arch_from_id("mips64-linux-gnuabin32",
bits=32)` now raises `ArchNotFound` where it used to answer `ArchMIPS32`. No
caller in cle or angr passes that combination.

With that, `binaries/tests/mips/busybox` completes the analysis and 3514 of 3518
functions get a calling convention, 3509 of 3518 a prototype, against 139 and
139 on the merge base.

After, every architecture archinfo exports resolves from its own `name`. By
class rather than by name one still does not, on both arms: `ArchARM.name` is
`"ARMEL"`, which is the alias relationship those two have.

Two things deliberately not done. A `reg_name in arch.registers` guard at
`fact_collector.py:449`: it would stop the crash and leave every MIPS32 binary
analysed with n32 argument facts -- silently wrong instead of loudly wrong --
and angr#6356 is already working that seam. And the GNU triplets
`mips64-linux-gnuabin32` / `mips64el-linux-gnuabin32`, which still resolve to
`ArchMIPS64` because `arch_from_id` reads `bits=64` out of the `64`. That is a
family property, not something left half-done: the `ArchARMHF` and
`ArchARMCortexM` triplets resolve to `ArchARMEL` the same way on both arms.

One consequence is worth stating, because it is a loss. 12 of the 343 o32
syscall prototypes take a 64-bit argument (`pread64`, `pwrite64`, `truncate64`,
`fallocate`, `readahead`, `sync_file_range`, ...), and `SimCCO32LinuxSyscall`
does not override `next_arg`, so the base implementation refuses to split one
across two 32-bit slots:

```text
ValueError: <SimCCO32LinuxSyscall> doesn't know how to store large types.
Consider overriding next_arg to implement its ABI logic
```

`SimCCO32`, the non-syscall o32 convention, lays out all 343 without raising,
and the n32 convention handled these 12 only because its argument slot is 8
bytes wide. The same 12 come back on the merge base, so this fix uncovers a gap
that was there all along rather than creating one. In a 60-function sample from
`busybox` it costs three functions their output (57 of 60 decompile to text
against 60 of 60 on the merge base), against 139 recovered conventions rising
to 3514 across the binary. That gap belongs to `SimCCO32LinuxSyscall` in angr
and is not fixed here.

### Testing

`tests/test_mips.py` gains `TestArchLookupByName`, five cases: `ArchMIPSN32` is
in `all_arches`; `arch_from_id(ArchMIPSN32.name)` is `ArchMIPSN32`; every class
in `archinfo.__all__` that has a `name` resolves from it; every o32 identifier
that resolved to `ArchMIPS32` before still does, in the endness it did before;
and the n32 identifiers carry their endness. `tests/test_mips.py` is 12 passed
on this head and `4 failed, 8 passed` on the merge base with the tests kept; the
o32 control is one of the eight that pass on both sides, so it shows the
exclusion regex changed nothing there rather than that the suite is inert.
`tests/` is 47 passed, 34 subtests passed on this head.

`register_arch` mutates `all_arches`, which angr walks in two places, and
archinfo's CI cannot see either; both were run against this head.
`test_boyscout.py` with `test_stack_alignment.py` is 16 passed, and
`test_calling_convention_analysis.py` with `tests/procedures/` is 98 passed,
4 skipped.

Validation: https://github.com/angr/archinfo/pull/385#issuecomment-5617774563

session: sharpen
